### PR TITLE
Fix bridging on L2 side

### DIFF
--- a/contracts/optimism/L2ERC20ExtendedTokensBridge.sol
+++ b/contracts/optimism/L2ERC20ExtendedTokensBridge.sol
@@ -158,7 +158,7 @@ contract L2ERC20ExtendedTokensBridge is
         sendCrossDomainMessage(L1_TOKEN_BRIDGE, l1Gas_, message);
     }
 
-    /// @notice Mints tokens and returns amount of minted tokens.
+    /// @notice Mints tokens, wraps if needed and returns amount of minted tokens.
     /// @param l2Token_ Address of L2 token for which deposit is finalizing.
     /// @param to_ Account that token mints for.
     /// @param amount_ Amount of token or shares to mint.
@@ -171,18 +171,16 @@ contract L2ERC20ExtendedTokensBridge is
         if(l2Token_ == L2_TOKEN_REBASABLE) {
             IERC20Bridged(L2_TOKEN_NON_REBASABLE).bridgeMint(address(this), amount_);
             IERC20(L2_TOKEN_NON_REBASABLE).safeIncreaseAllowance(l2Token_, amount_);
-            uint256 rebasableTokensAmount;
             if (amount_ != 0) {
-                rebasableTokensAmount = ERC20RebasableBridged(l2Token_).wrap(amount_);
+                ERC20RebasableBridged(l2Token_).wrap(amount_);
             }
-            ERC20RebasableBridged(l2Token_).transferShares(to_, amount_);
-            return rebasableTokensAmount;
+            return ERC20RebasableBridged(l2Token_).transferShares(to_, amount_);
         }
         IERC20Bridged(l2Token_).bridgeMint(to_, amount_);
         return amount_;
     }
 
-    /// @notice Burns tokens and returns amount of non-rebasable token to withdraw.
+    /// @notice Unwraps if needed, burns tokens and returns amount of non-rebasable token to withdraw.
     /// @param l2Token_ Address of L2 token where withdrawal was initiated.
     /// @param from_ Account which tokens are burns.
     /// @param amount_ Amount of token to burn.
@@ -193,13 +191,12 @@ contract L2ERC20ExtendedTokensBridge is
         uint256 amount_
     ) internal returns (uint256) {
         if(l2Token_ == L2_TOKEN_REBASABLE) {
-            ERC20RebasableBridged(l2Token_).transferFrom(from_, address(this), amount_);
-            uint256 nonRebasableTokensAmount;
+            uint256 nonRebasableTokenAmount;
             if (amount_ != 0) {
-                nonRebasableTokensAmount = ERC20RebasableBridged(l2Token_).unwrap(amount_);
+                nonRebasableTokenAmount = ERC20RebasableBridged(l2Token_).bridgeUnwrap(from_, amount_);
             }
-            IERC20Bridged(L2_TOKEN_NON_REBASABLE).bridgeBurn(address(this), nonRebasableTokensAmount);
-            return nonRebasableTokensAmount;
+            IERC20Bridged(L2_TOKEN_NON_REBASABLE).bridgeBurn(from_, nonRebasableTokenAmount);
+            return nonRebasableTokenAmount;
         }
         IERC20Bridged(l2Token_).bridgeBurn(from_, amount_);
         return amount_;

--- a/contracts/token/ERC20Bridged.sol
+++ b/contracts/token/ERC20Bridged.sol
@@ -33,7 +33,7 @@ contract ERC20Bridged is IERC20Bridged, ERC20Core, ERC20Metadata {
     /// @param name_ The name of the token
     /// @param symbol_ The symbol of the token
     /// @param decimals_ The decimals places of the token
-    /// @param bridge_ The bridge address which allowd to mint/burn tokens
+    /// @param bridge_ The bridge address which allows to mint/burn tokens
     constructor(
         string memory name_,
         string memory symbol_,

--- a/contracts/token/ERC20BridgedPermit.sol
+++ b/contracts/token/ERC20BridgedPermit.sol
@@ -15,7 +15,7 @@ contract ERC20BridgedPermit is ERC20Bridged, PermitExtension, Versioned {
     /// @param symbol_ The symbol of the token
     /// @param version_ The current major version of the signing domain (aka token version)
     /// @param decimals_ The decimals places of the token
-    /// @param bridge_ The bridge address which allowd to mint/burn tokens
+    /// @param bridge_ The bridge address which allows to mint/burn tokens
     constructor(
         string memory name_,
         string memory symbol_,

--- a/contracts/token/ERC20RebasableBridged.sol
+++ b/contracts/token/ERC20RebasableBridged.sol
@@ -13,7 +13,7 @@ import {UnstructuredStorage} from "../lib/UnstructuredStorage.sol";
 
 /// @author kovalgek
 /// @notice Extends the ERC20 functionality that allows the bridge to wrap/unwrap token.
-interface IBridgeWrappable {
+interface IBridgeWrapper {
     /// @notice Returns bridge which can wrap/unwrap token on L2.
     function L2_ERC20_TOKEN_BRIDGE() external view returns (address);
 
@@ -32,12 +32,12 @@ interface IBridgeWrappable {
 
 /// @author kovalgek
 /// @notice Rebasable token that wraps/unwraps non-rebasable token and allow to mint/burn tokens by bridge.
-contract ERC20RebasableBridged is IERC20, IERC20Wrapper, IBridgeWrappable, ERC20Metadata {
+contract ERC20RebasableBridged is IERC20, IERC20Wrapper, IBridgeWrapper, ERC20Metadata {
     using SafeERC20 for IERC20;
     using UnstructuredRefStorage for bytes32;
     using UnstructuredStorage for bytes32;
 
-    /// @inheritdoc IBridgeWrappable
+    /// @inheritdoc IBridgeWrapper
     address public immutable L2_ERC20_TOKEN_BRIDGE;
 
     /// @notice Contract of non-rebasable token to wrap from.
@@ -84,12 +84,12 @@ contract ERC20RebasableBridged is IERC20, IERC20Wrapper, IBridgeWrappable, ERC20
         return _unwrap(msg.sender, tokenAmount_);
     }
 
-    /// @inheritdoc IBridgeWrappable
+    /// @inheritdoc IBridgeWrapper
     function bridgeWrap(address account_, uint256 sharesAmount_) external onlyBridge returns (uint256) {
         return _wrap(L2_ERC20_TOKEN_BRIDGE, account_, sharesAmount_);
     }
 
-    /// @inheritdoc IBridgeWrappable
+    /// @inheritdoc IBridgeWrapper
     function bridgeUnwrap(address account_, uint256 tokenAmount_) external onlyBridge returns (uint256) {
         return _unwrap(account_, tokenAmount_);
     }

--- a/contracts/token/ERC20RebasableBridged.sol
+++ b/contracts/token/ERC20RebasableBridged.sol
@@ -12,20 +12,10 @@ import {UnstructuredRefStorage} from "../lib/UnstructuredRefStorage.sol";
 import {UnstructuredStorage} from "../lib/UnstructuredStorage.sol";
 
 /// @author kovalgek
-/// @notice Extends the ERC20 functionality that allows the bridge to mint/burn shares
-interface IERC20BridgedShares is IERC20 {
-    /// @notice Returns bridge which can mint and burn shares on L2
+/// @notice Extends the ERC20 functionality that allows the bridge to unwrap token.
+interface IBridgeUnwrappable {
+    /// @notice Returns bridge which can unwrap token on L2.
     function L2_ERC20_TOKEN_BRIDGE() external view returns (address);
-
-    /// @notice Creates amount_ shares and assigns them to account_, increasing the total shares supply
-    /// @param account_ An address of the account to mint shares
-    /// @param amount_ An amount of shares to mint
-    function bridgeMintShares(address account_, uint256 amount_) external;
-
-    /// @notice Destroys amount_ shares from account_, reducing the total shares supply
-    /// @param account_ An address of the account to burn shares
-    /// @param amount_ An amount of shares to burn
-    function bridgeBurnShares(address account_, uint256 amount_) external;
 
     /// @notice Exchanges wrapper token to wrappable one. Can be called by bridge only.
     /// @param account_ An address of the account to unwrap token for
@@ -36,12 +26,12 @@ interface IERC20BridgedShares is IERC20 {
 
 /// @author kovalgek
 /// @notice Rebasable token that wraps/unwraps non-rebasable token and allow to mint/burn tokens by bridge.
-contract ERC20RebasableBridged is IERC20, IERC20Wrapper, IERC20BridgedShares, ERC20Metadata {
+contract ERC20RebasableBridged is IERC20, IERC20Wrapper, IBridgeUnwrappable, ERC20Metadata {
     using SafeERC20 for IERC20;
     using UnstructuredRefStorage for bytes32;
     using UnstructuredStorage for bytes32;
 
-    /// @inheritdoc IERC20BridgedShares
+    /// @inheritdoc IBridgeUnwrappable
     address public immutable L2_ERC20_TOKEN_BRIDGE;
 
     /// @notice Contract of non-rebasable token to wrap from.
@@ -93,19 +83,9 @@ contract ERC20RebasableBridged is IERC20, IERC20Wrapper, IERC20BridgedShares, ER
         return _unwrap(msg.sender, tokenAmount_);
     }
 
-    /// @inheritdoc IERC20BridgedShares
+    /// @inheritdoc IBridgeUnwrappable
     function bridgeUnwrap(address account_, uint256 amount_) external onlyBridge returns (uint256) {
         return _unwrap(account_, amount_);
-    }
-
-    /// @inheritdoc IERC20BridgedShares
-    function bridgeMintShares(address account_, uint256 amount_) external onlyBridge {
-        _mintShares(account_, amount_);
-    }
-
-    /// @inheritdoc IERC20BridgedShares
-    function bridgeBurnShares(address account_, uint256 amount_) external onlyBridge {
-        _burnShares(account_, amount_);
     }
 
     /// @inheritdoc IERC20

--- a/contracts/token/PermitExtension.sol
+++ b/contracts/token/PermitExtension.sol
@@ -19,7 +19,7 @@ abstract contract PermitExtension is IERC2612, EIP712 {
         string version;
     }
 
-    /// @dev user shares slot position.
+    /// @dev user nonce slot position.
     bytes32 internal constant NONCE_BY_ADDRESS_POSITION = keccak256("PermitExtension.NONCE_BY_ADDRESS_POSITION");
 
     /// @dev Typehash constant for ERC-2612 (Permit)

--- a/test/optimism/L2ERC20ExtendedTokensBridge.unit.test.ts
+++ b/test/optimism/L2ERC20ExtendedTokensBridge.unit.test.ts
@@ -278,6 +278,8 @@ unit("Optimism:: L2ERC20ExtendedTokensBridge", ctxFactory)
     const recipientBalanceBefore = await l2TokenRebasable.balanceOf(recipient.address);
     const totalSupplyBefore = await l2TokenRebasable.totalSupply();
 
+    await l2TokenRebasable.connect(recipient).approve(l2TokenBridge.address, amountToWithdraw);
+
     const tx = await l2TokenBridge.connect(recipient).withdraw(
       l2TokenRebasable.address,
       amountToWithdraw,
@@ -565,7 +567,7 @@ unit("Optimism:: L2ERC20ExtendedTokensBridge", ctxFactory)
       },
     } = ctx;
 
-    const amountToDeposit = wei`1 ether`;
+    const amountToDeposit = wei`1 ether`; // shares
     const amountToWithdraw = wei.toBigNumber(amountToDeposit).mul(ctx.exchangeRate).div(ctx.decimalsBN);
     const l1Gas = wei`1 wei`;
     const data = "0xdeadbeaf";
@@ -585,6 +587,8 @@ unit("Optimism:: L2ERC20ExtendedTokensBridge", ctxFactory)
 
     const deployerBalanceBefore = await l2TokenRebasable.balanceOf(deployer.address);
     const totalSupplyBefore = await l2TokenRebasable.totalSupply();
+
+    await l2TokenRebasable.approve(l2TokenBridge.address, amountToWithdraw);
 
     const tx = await l2TokenBridge.connect(deployer).withdrawTo(
       l2TokenRebasable.address,
@@ -1015,8 +1019,8 @@ unit("Optimism:: L2ERC20ExtendedTokensBridge", ctxFactory)
 
     await l2Messenger.setXDomainMessageSender(l1TokenBridgeEOA.address);
 
-    const amountToDeposit = wei`1 ether`;
-    const amountToEmit = wei.toBigNumber(amountToDeposit).mul(ctx.exchangeRate).div(ctx.decimalsBN);
+    const amountOfSharesToDeposit = wei`1 ether`;
+    const amountOfRebasableToken = wei.toBigNumber(amountOfSharesToDeposit).mul(ctx.exchangeRate).div(ctx.decimalsBN);
     const data = "0xdeadbeaf";
     const provider = await hre.ethers.provider;
     const packedTokenRateAndTimestampData = await packedTokenRateAndTimestamp(provider, ctx.exchangeRate);
@@ -1029,7 +1033,7 @@ unit("Optimism:: L2ERC20ExtendedTokensBridge", ctxFactory)
         l2TokenRebasable.address,
         deployer.address,
         recipient.address,
-        amountToDeposit,
+        amountOfSharesToDeposit,
         dataToReceive
       );
 
@@ -1038,11 +1042,11 @@ unit("Optimism:: L2ERC20ExtendedTokensBridge", ctxFactory)
       l2TokenRebasable.address,
       deployer.address,
       recipient.address,
-      amountToEmit,
+      amountOfRebasableToken,
       data,
     ]);
 
-    assert.equalBN(await l2TokenRebasable.balanceOf(recipient.address), amountToEmit);
+    assert.equalBN(await l2TokenRebasable.balanceOf(recipient.address), amountOfRebasableToken);
   })
 
   .run();

--- a/test/optimism/L2ERC20ExtendedTokensBridge.unit.test.ts
+++ b/test/optimism/L2ERC20ExtendedTokensBridge.unit.test.ts
@@ -278,8 +278,6 @@ unit("Optimism:: L2ERC20ExtendedTokensBridge", ctxFactory)
     const recipientBalanceBefore = await l2TokenRebasable.balanceOf(recipient.address);
     const totalSupplyBefore = await l2TokenRebasable.totalSupply();
 
-    await l2TokenRebasable.connect(recipient).approve(l2TokenBridge.address, amountToWithdraw);
-
     const tx = await l2TokenBridge.connect(recipient).withdraw(
       l2TokenRebasable.address,
       amountToWithdraw,
@@ -587,8 +585,6 @@ unit("Optimism:: L2ERC20ExtendedTokensBridge", ctxFactory)
 
     const deployerBalanceBefore = await l2TokenRebasable.balanceOf(deployer.address);
     const totalSupplyBefore = await l2TokenRebasable.totalSupply();
-
-    await l2TokenRebasable.approve(l2TokenBridge.address, amountToWithdraw);
 
     const tx = await l2TokenBridge.connect(deployer).withdrawTo(
       l2TokenRebasable.address,

--- a/test/optimism/L2ERC20ExtendedTokensBridge.unit.test.ts
+++ b/test/optimism/L2ERC20ExtendedTokensBridge.unit.test.ts
@@ -21,12 +21,23 @@ import {
 
 unit("Optimism:: L2ERC20ExtendedTokensBridge", ctxFactory)
   .test("initial state", async (ctx) => {
-    assert.equal(await ctx.l2TokenBridge.l1TokenBridge(), ctx.accounts.l1TokenBridgeEOA.address);
-    assert.equal(await ctx.l2TokenBridge.MESSENGER(), ctx.accounts.l2MessengerStubEOA._address);
-    assert.equal(await ctx.l2TokenBridge.L1_TOKEN_NON_REBASABLE(), ctx.stubs.l1TokenNonRebasable.address);
-    assert.equal(await ctx.l2TokenBridge.L1_TOKEN_REBASABLE(), ctx.stubs.l1TokenRebasable.address);
-    assert.equal(await ctx.l2TokenBridge.L2_TOKEN_NON_REBASABLE(), ctx.stubs.l2TokenNonRebasable.address);
-    assert.equal(await ctx.l2TokenBridge.L2_TOKEN_REBASABLE(), ctx.stubs.l2TokenRebasable.address);
+    const {
+      l2TokenBridge,
+      accounts: {l1TokenBridgeEOA, l2MessengerStubEOA},
+      stubs: { l1TokenNonRebasable, l2TokenNonRebasable, l1TokenRebasable, l2TokenRebasable },
+    } = ctx;
+
+    assert.equal(await l2TokenBridge.l1TokenBridge(), l1TokenBridgeEOA.address);
+    assert.equal(await l2TokenBridge.MESSENGER(), l2MessengerStubEOA._address);
+    assert.equal(await l2TokenBridge.L1_TOKEN_NON_REBASABLE(), l1TokenNonRebasable.address);
+    assert.equal(await l2TokenBridge.L1_TOKEN_REBASABLE(), l1TokenRebasable.address);
+    assert.equal(await l2TokenBridge.L2_TOKEN_NON_REBASABLE(), l2TokenNonRebasable.address);
+    assert.equal(await l2TokenBridge.L2_TOKEN_REBASABLE(), l2TokenRebasable.address);
+
+    assert.equalBN(
+      await l2TokenNonRebasable.allowance(l2TokenBridge.address, l2TokenRebasable.address),
+      hre.ethers.constants.MaxUint256
+    );
   })
 
   .test("initialize() :: petrified", async (ctx) => {

--- a/test/optimism/_launch.test.ts
+++ b/test/optimism/_launch.test.ts
@@ -6,6 +6,7 @@ import optimism from "../../utils/optimism";
 import testing, { scenario } from "../../utils/testing";
 import { BridgingManagerRole } from "../../utils/bridging-management";
 import { L1LidoTokensBridge__factory } from "../../typechain";
+import { BigNumber } from 'ethers'
 
 const REVERT = env.bool("REVERT", true);
 
@@ -57,7 +58,7 @@ async function ctxFactory() {
 
   const { l1Provider, l2Provider, l1LidoTokensBridge } = await optimism
     .testing(networkName)
-    .getIntegrationTestSetup();
+    .getIntegrationTestSetup(BigNumber.from('1164454276599657236'));
 
   const hasDeployedContracts = testing.env.USE_DEPLOYED_CONTRACTS(false);
   const l1DevMultisig = hasDeployedContracts

--- a/test/optimism/bridging-non-rebasable.integration.test.ts
+++ b/test/optimism/bridging-non-rebasable.integration.test.ts
@@ -1,625 +1,661 @@
 import { assert } from "chai";
-
+import { ethers } from "hardhat";
+import { BigNumber } from 'ethers'
 import env from "../../utils/env";
 import { wei } from "../../utils/wei";
 import optimism from "../../utils/optimism";
 import testing, { scenario } from "../../utils/testing";
-import { ethers } from "hardhat";
-import { JsonRpcProvider } from "@ethersproject/providers";
+import { ScenarioTest } from "../../utils/testing";
 import { ERC20WrapperStub } from "../../typechain";
+import { JsonRpcProvider } from "@ethersproject/providers";
 
-scenario("Optimism :: Bridging non-rebasable token integration test", ctxFactory)
-  .after(async (ctx) => {
-    await ctx.l1Provider.send("evm_revert", [ctx.snapshot.l1]);
-    await ctx.l2Provider.send("evm_revert", [ctx.snapshot.l2]);
-  })
+type ContextType = Awaited<ReturnType<ReturnType<typeof ctxFactory>>>
 
-  .step("Activate bridging on L1", async (ctx) => {
-    const { l1LidoTokensBridge } = ctx;
-    const { l1ERC20ExtendedTokensBridgeAdmin } = ctx.accounts;
+function bridgingTestsSuit(scenarioInstance: ScenarioTest<ContextType>) {
+  scenarioInstance
+    .after(async (ctx) => {
+      await ctx.l1Provider.send("evm_revert", [ctx.snapshot.l1]);
+      await ctx.l2Provider.send("evm_revert", [ctx.snapshot.l2]);
+    })
 
-    const isDepositsEnabled = await l1LidoTokensBridge.isDepositsEnabled();
+    .step("Activate bridging on L1", async (ctx) => {
+      const { l1LidoTokensBridge } = ctx;
+      const { l1ERC20ExtendedTokensBridgeAdmin } = ctx.accounts;
 
-    if (!isDepositsEnabled) {
-      await l1LidoTokensBridge
-        .connect(l1ERC20ExtendedTokensBridgeAdmin)
-        .enableDeposits();
-    } else {
-      console.log("L1 deposits already enabled");
-    }
+      const isDepositsEnabled = await l1LidoTokensBridge.isDepositsEnabled();
 
-    const isWithdrawalsEnabled =
-      await l1LidoTokensBridge.isWithdrawalsEnabled();
+      if (!isDepositsEnabled) {
+        await l1LidoTokensBridge
+          .connect(l1ERC20ExtendedTokensBridgeAdmin)
+          .enableDeposits();
+      } else {
+        console.log("L1 deposits already enabled");
+      }
 
-    if (!isWithdrawalsEnabled) {
-      await l1LidoTokensBridge
-        .connect(l1ERC20ExtendedTokensBridgeAdmin)
-        .enableWithdrawals();
-    } else {
-      console.log("L1 withdrawals already enabled");
-    }
+      const isWithdrawalsEnabled =
+        await l1LidoTokensBridge.isWithdrawalsEnabled();
 
-    assert.isTrue(await l1LidoTokensBridge.isDepositsEnabled());
-    assert.isTrue(await l1LidoTokensBridge.isWithdrawalsEnabled());
-  })
+      if (!isWithdrawalsEnabled) {
+        await l1LidoTokensBridge
+          .connect(l1ERC20ExtendedTokensBridgeAdmin)
+          .enableWithdrawals();
+      } else {
+        console.log("L1 withdrawals already enabled");
+      }
 
-  .step("Activate bridging on L2", async (ctx) => {
-    const { l2ERC20ExtendedTokensBridge } = ctx;
-    const { l2ERC20ExtendedTokensBridgeAdmin } = ctx.accounts;
+      assert.isTrue(await l1LidoTokensBridge.isDepositsEnabled());
+      assert.isTrue(await l1LidoTokensBridge.isWithdrawalsEnabled());
+    })
 
-    const isDepositsEnabled = await l2ERC20ExtendedTokensBridge.isDepositsEnabled();
+    .step("Activate bridging on L2", async (ctx) => {
+      const { l2ERC20ExtendedTokensBridge } = ctx;
+      const { l2ERC20ExtendedTokensBridgeAdmin } = ctx.accounts;
 
-    if (!isDepositsEnabled) {
-      await l2ERC20ExtendedTokensBridge
-        .connect(l2ERC20ExtendedTokensBridgeAdmin)
-        .enableDeposits();
-    } else {
-      console.log("L2 deposits already enabled");
-    }
+      const isDepositsEnabled = await l2ERC20ExtendedTokensBridge.isDepositsEnabled();
 
-    const isWithdrawalsEnabled =
-      await l2ERC20ExtendedTokensBridge.isWithdrawalsEnabled();
+      if (!isDepositsEnabled) {
+        await l2ERC20ExtendedTokensBridge
+          .connect(l2ERC20ExtendedTokensBridgeAdmin)
+          .enableDeposits();
+      } else {
+        console.log("L2 deposits already enabled");
+      }
 
-    if (!isWithdrawalsEnabled) {
-      await l2ERC20ExtendedTokensBridge
-        .connect(l2ERC20ExtendedTokensBridgeAdmin)
-        .enableWithdrawals();
-    } else {
-      console.log("L2 withdrawals already enabled");
-    }
+      const isWithdrawalsEnabled =
+        await l2ERC20ExtendedTokensBridge.isWithdrawalsEnabled();
 
-    assert.isTrue(await l2ERC20ExtendedTokensBridge.isDepositsEnabled());
-    assert.isTrue(await l2ERC20ExtendedTokensBridge.isWithdrawalsEnabled());
-  })
+      if (!isWithdrawalsEnabled) {
+        await l2ERC20ExtendedTokensBridge
+          .connect(l2ERC20ExtendedTokensBridgeAdmin)
+          .enableWithdrawals();
+      } else {
+        console.log("L2 withdrawals already enabled");
+      }
 
-  .step("L1 -> L2 deposit via depositERC20() method", async (ctx) => {
-    const {
-      l1Token,
-      l1LidoTokensBridge,
-      l2Token,
-      l1CrossDomainMessenger,
-      l2ERC20ExtendedTokensBridge,
-    } = ctx;
-    const { accountA: tokenHolderA } = ctx.accounts;
-    const { depositAmount } = ctx.common;
+      assert.isTrue(await l2ERC20ExtendedTokensBridge.isDepositsEnabled());
+      assert.isTrue(await l2ERC20ExtendedTokensBridge.isWithdrawalsEnabled());
+    })
 
-    await l1Token
-      .connect(tokenHolderA.l1Signer)
-      .approve(l1LidoTokensBridge.address, depositAmount);
+    .step("L1 -> L2 deposit via depositERC20() method", async (ctx) => {
+      const {
+        l1Token,
+        l1LidoTokensBridge,
+        l2Token,
+        l1CrossDomainMessenger,
+        l2ERC20ExtendedTokensBridge,
+      } = ctx;
+      const { accountA: tokenHolderA } = ctx.accounts;
+      const { depositAmount } = ctx.constants;
 
-    const tokenHolderABalanceBefore = await l1Token.balanceOf(
-      tokenHolderA.address
-    );
-    const l1ERC20ExtendedTokensBridgeBalanceBefore = await l1Token.balanceOf(
-      l1LidoTokensBridge.address
-    );
+      await l1Token
+        .connect(tokenHolderA.l1Signer)
+        .approve(l1LidoTokensBridge.address, depositAmount);
 
-    const tx = await l1LidoTokensBridge
-      .connect(tokenHolderA.l1Signer)
-      .depositERC20(
-        l1Token.address,
-        l2Token.address,
-        depositAmount,
-        200_000,
-        "0x"
-      );
+      const tokenHolderABalanceBefore = await l1Token.balanceOf(tokenHolderA.address);
+      const l1ERC20ExtendedTokensBridgeBalanceBefore = await l1Token.balanceOf(l1LidoTokensBridge.address);
 
-    const dataToSend = await packedTokenRateAndTimestamp(ctx.l1Provider, l1Token);
+      ctx.balances.accountABalanceBeforeDeposit = tokenHolderABalanceBefore;
 
-    await assert.emits(l1LidoTokensBridge, tx, "ERC20DepositInitiated", [
-      l1Token.address,
-      l2Token.address,
-      tokenHolderA.address,
-      tokenHolderA.address,
-      depositAmount,
-      dataToSend,
-    ]);
+      const tx = await l1LidoTokensBridge
+        .connect(tokenHolderA.l1Signer)
+        .depositERC20(
+          l1Token.address,
+          l2Token.address,
+          depositAmount,
+          200_000,
+          "0x"
+        );
 
-    const l2DepositCalldata = l2ERC20ExtendedTokensBridge.interface.encodeFunctionData(
-      "finalizeDeposit",
-      [
+      const dataToSend = await packedTokenRateAndTimestamp(ctx.l1Provider, l1Token);
+
+      await assert.emits(l1LidoTokensBridge, tx, "ERC20DepositInitiated", [
         l1Token.address,
         l2Token.address,
         tokenHolderA.address,
         tokenHolderA.address,
         depositAmount,
         dataToSend,
-      ]
-    );
+      ]);
 
-    const messageNonce = await l1CrossDomainMessenger.messageNonce();
-
-    await assert.emits(l1CrossDomainMessenger, tx, "SentMessage", [
-      l2ERC20ExtendedTokensBridge.address,
-      l1LidoTokensBridge.address,
-      l2DepositCalldata,
-      messageNonce,
-      200_000,
-    ]);
-
-    assert.equalBN(
-      await l1Token.balanceOf(l1LidoTokensBridge.address),
-      l1ERC20ExtendedTokensBridgeBalanceBefore.add(depositAmount)
-    );
-
-    assert.equalBN(
-      await l1Token.balanceOf(tokenHolderA.address),
-      tokenHolderABalanceBefore.sub(depositAmount)
-    );
-  })
-
-  .step("Finalize deposit on L2", async (ctx) => {
-    const {
-      l1Token,
-      l2Token,
-      l1LidoTokensBridge,
-      l2CrossDomainMessenger,
-      l2ERC20ExtendedTokensBridge,
-    } = ctx;
-    const { depositAmount } = ctx.common;
-    const { accountA: tokenHolderA, l1CrossDomainMessengerAliased } =
-      ctx.accounts;
-
-    const tokenHolderABalanceBefore = await l2Token.balanceOf(
-      tokenHolderA.address
-    );
-    const l2TokenTotalSupplyBefore = await l2Token.totalSupply();
-    const dataToReceive = await packedTokenRateAndTimestamp(ctx.l2Provider, l1Token);
-
-    const tx = await l2CrossDomainMessenger
-      .connect(l1CrossDomainMessengerAliased)
-      .relayMessage(
-        1,
-        l1LidoTokensBridge.address,
-        l2ERC20ExtendedTokensBridge.address,
-        0,
-        300_000,
-        l2ERC20ExtendedTokensBridge.interface.encodeFunctionData("finalizeDeposit", [
+      const l2DepositCalldata = l2ERC20ExtendedTokensBridge.interface.encodeFunctionData(
+        "finalizeDeposit",
+        [
           l1Token.address,
           l2Token.address,
           tokenHolderA.address,
           tokenHolderA.address,
           depositAmount,
-          dataToReceive,
-        ]),
-        { gasLimit: 5_000_000 }
+          dataToSend,
+        ]
       );
 
-    await assert.emits(l2ERC20ExtendedTokensBridge, tx, "DepositFinalized", [
-      l1Token.address,
-      l2Token.address,
-      tokenHolderA.address,
-      tokenHolderA.address,
-      depositAmount,
-      "0x",
-    ]);
-    assert.equalBN(
-      await l2Token.balanceOf(tokenHolderA.address),
-      tokenHolderABalanceBefore.add(depositAmount)
-    );
-    assert.equalBN(
-      await l2Token.totalSupply(),
-      l2TokenTotalSupplyBefore.add(depositAmount)
-    );
-  })
+      const messageNonce = await l1CrossDomainMessenger.messageNonce();
 
-  .step("L2 -> L1 withdrawal via withdraw()", async (ctx) => {
-    const { accountA: tokenHolderA } = ctx.accounts;
-    const { withdrawalAmount } = ctx.common;
-    const { l1Token, l2Token, l2ERC20ExtendedTokensBridge } = ctx;
-
-    const tokenHolderABalanceBefore = await l2Token.balanceOf(
-      tokenHolderA.address
-    );
-    const l2TotalSupplyBefore = await l2Token.totalSupply();
-
-    const tx = await l2ERC20ExtendedTokensBridge
-      .connect(tokenHolderA.l2Signer)
-      .withdraw(l2Token.address, withdrawalAmount, 0, "0x");
-
-    await assert.emits(l2ERC20ExtendedTokensBridge, tx, "WithdrawalInitiated", [
-      l1Token.address,
-      l2Token.address,
-      tokenHolderA.address,
-      tokenHolderA.address,
-      withdrawalAmount,
-      "0x",
-    ]);
-    assert.equalBN(
-      await l2Token.balanceOf(tokenHolderA.address),
-      tokenHolderABalanceBefore.sub(withdrawalAmount)
-    );
-    assert.equalBN(
-      await l2Token.totalSupply(),
-      l2TotalSupplyBefore.sub(withdrawalAmount)
-    );
-  })
-
-  .step("Finalize withdrawal on L1", async (ctx) => {
-    const {
-      l1Token,
-      l1CrossDomainMessenger,
-      l1LidoTokensBridge,
-      l2CrossDomainMessenger,
-      l2Token,
-      l2ERC20ExtendedTokensBridge,
-    } = ctx;
-    const { accountA: tokenHolderA, l1Stranger } = ctx.accounts;
-    const { withdrawalAmount } = ctx.common;
-
-    const tokenHolderABalanceBefore = await l1Token.balanceOf(
-      tokenHolderA.address
-    );
-    const l1ERC20ExtendedTokensBridgeBalanceBefore = await l1Token.balanceOf(
-      l1LidoTokensBridge.address
-    );
-
-    await l1CrossDomainMessenger
-      .connect(l1Stranger)
-      .setXDomainMessageSender(l2ERC20ExtendedTokensBridge.address);
-
-    const tx = await l1CrossDomainMessenger
-      .connect(l1Stranger)
-      .relayMessage(
+      await assert.emits(l1CrossDomainMessenger, tx, "SentMessage", [
+        l2ERC20ExtendedTokensBridge.address,
         l1LidoTokensBridge.address,
-        l2CrossDomainMessenger.address,
-        l1LidoTokensBridge.interface.encodeFunctionData(
-          "finalizeERC20Withdrawal",
-          [
+        l2DepositCalldata,
+        messageNonce,
+        200_000,
+      ]);
+
+      assert.equalBN(
+        await l1Token.balanceOf(l1LidoTokensBridge.address),
+        l1ERC20ExtendedTokensBridgeBalanceBefore.add(depositAmount)
+      );
+
+      assert.equalBN(
+        await l1Token.balanceOf(tokenHolderA.address),
+        tokenHolderABalanceBefore.sub(depositAmount)
+      );
+    })
+
+    .step("Finalize deposit on L2", async (ctx) => {
+      const {
+        l1Token,
+        l2Token,
+        l1LidoTokensBridge,
+        l2CrossDomainMessenger,
+        l2ERC20ExtendedTokensBridge,
+      } = ctx;
+      const { depositAmount } = ctx.constants;
+
+      const { accountA: tokenHolderA, l1CrossDomainMessengerAliased } =
+        ctx.accounts;
+
+      const tokenHolderABalanceBefore = await l2Token.balanceOf(tokenHolderA.address);
+      const l2TokenTotalSupplyBefore = await l2Token.totalSupply();
+
+      const dataToReceive = await packedTokenRateAndTimestamp(ctx.l2Provider, l1Token);
+
+      const tx = await l2CrossDomainMessenger
+        .connect(l1CrossDomainMessengerAliased)
+        .relayMessage(
+          1,
+          l1LidoTokensBridge.address,
+          l2ERC20ExtendedTokensBridge.address,
+          0,
+          300_000,
+          l2ERC20ExtendedTokensBridge.interface.encodeFunctionData("finalizeDeposit", [
             l1Token.address,
             l2Token.address,
             tokenHolderA.address,
             tokenHolderA.address,
-            withdrawalAmount,
-            "0x",
-          ]
-        ),
-        0
-      );
+            depositAmount,
+            dataToReceive,
+          ]),
+          { gasLimit: 5_000_000 }
+        );
 
-    await assert.emits(l1LidoTokensBridge, tx, "ERC20WithdrawalFinalized", [
-      l1Token.address,
-      l2Token.address,
-      tokenHolderA.address,
-      tokenHolderA.address,
-      withdrawalAmount,
-      "0x",
-    ]);
-
-    assert.equalBN(
-      await l1Token.balanceOf(l1LidoTokensBridge.address),
-      l1ERC20ExtendedTokensBridgeBalanceBefore.sub(withdrawalAmount)
-    );
-
-    assert.equalBN(
-      await l1Token.balanceOf(tokenHolderA.address),
-      tokenHolderABalanceBefore.add(withdrawalAmount)
-    );
-  })
-
-  .step("L1 -> L2 deposit via depositERC20To()", async (ctx) => {
-    const {
-      l1Token,
-      l2Token,
-      l1LidoTokensBridge,
-      l2ERC20ExtendedTokensBridge,
-      l1CrossDomainMessenger,
-    } = ctx;
-    const { accountA: tokenHolderA, accountB: tokenHolderB } = ctx.accounts;
-    const { depositAmount } = ctx.common;
-
-    assert.notEqual(tokenHolderA.address, tokenHolderB.address);
-
-    await l1Token
-      .connect(tokenHolderA.l1Signer)
-      .approve(l1LidoTokensBridge.address, depositAmount);
-
-    const tokenHolderABalanceBefore = await l1Token.balanceOf(
-      tokenHolderA.address
-    );
-    const l1ERC20ExtendedTokensBridgeBalanceBefore = await l1Token.balanceOf(
-      l1LidoTokensBridge.address
-    );
-
-    const tx = await l1LidoTokensBridge
-      .connect(tokenHolderA.l1Signer)
-      .depositERC20To(
+      await assert.emits(l2ERC20ExtendedTokensBridge, tx, "DepositFinalized", [
         l1Token.address,
         l2Token.address,
-        tokenHolderB.address,
+        tokenHolderA.address,
+        tokenHolderA.address,
         depositAmount,
-        200_000,
-        "0x"
+        "0x",
+      ]);
+      assert.equalBN(
+        await l2Token.balanceOf(tokenHolderA.address),
+        tokenHolderABalanceBefore.add(depositAmount)
+      );
+      assert.equalBN(
+        await l2Token.totalSupply(),
+        l2TokenTotalSupplyBefore.add(depositAmount)
+      );
+    })
+
+    .step("L2 -> L1 withdrawal via withdraw()", async (ctx) => {
+      const { accountA: tokenHolderA } = ctx.accounts;
+      const { withdrawalAmount } = ctx.constants;
+      const { l1Token, l2Token, l2ERC20ExtendedTokensBridge } = ctx;
+
+      const tokenHolderABalanceBefore = await l2Token.balanceOf(tokenHolderA.address);
+      const l2TotalSupplyBefore = await l2Token.totalSupply();
+
+      const tx = await l2ERC20ExtendedTokensBridge
+        .connect(tokenHolderA.l2Signer)
+        .withdraw(l2Token.address, withdrawalAmount, 0, "0x");
+
+      await assert.emits(l2ERC20ExtendedTokensBridge, tx, "WithdrawalInitiated", [
+        l1Token.address,
+        l2Token.address,
+        tokenHolderA.address,
+        tokenHolderA.address,
+        withdrawalAmount,
+        "0x",
+      ]);
+
+      const tokenHolderABalanceAfter = await l2Token.balanceOf(tokenHolderA.address);
+      const l2TotalSupplyAfter = await l2Token.totalSupply();
+
+      assert.equalBN(
+        tokenHolderABalanceAfter,
+        tokenHolderABalanceBefore.sub(withdrawalAmount)
+      );
+      assert.equalBN(
+        l2TotalSupplyAfter,
+        l2TotalSupplyBefore.sub(withdrawalAmount)
+      );
+    })
+
+    .step("Finalize withdrawal on L1", async (ctx) => {
+      const {
+        l1Token,
+        l1CrossDomainMessenger,
+        l1LidoTokensBridge,
+        l2CrossDomainMessenger,
+        l2Token,
+        l2ERC20ExtendedTokensBridge,
+      } = ctx;
+      const { accountA: tokenHolderA, l1Stranger } = ctx.accounts;
+      const { depositAmount, withdrawalAmount } = ctx.constants;
+
+      const tokenHolderABalanceBefore = await l1Token.balanceOf(
+        tokenHolderA.address
+      );
+      const l1ERC20ExtendedTokensBridgeBalanceBefore = await l1Token.balanceOf(
+        l1LidoTokensBridge.address
       );
 
-    const dataToSend = await packedTokenRateAndTimestamp(ctx.l1Provider, l1Token);
+      await l1CrossDomainMessenger
+        .connect(l1Stranger)
+        .setXDomainMessageSender(l2ERC20ExtendedTokensBridge.address);
 
-    await assert.emits(l1LidoTokensBridge, tx, "ERC20DepositInitiated", [
-      l1Token.address,
-      l2Token.address,
-      tokenHolderA.address,
-      tokenHolderB.address,
-      depositAmount,
-      dataToSend,
-    ]);
+      const tx = await l1CrossDomainMessenger
+        .connect(l1Stranger)
+        .relayMessage(
+          l1LidoTokensBridge.address,
+          l2CrossDomainMessenger.address,
+          l1LidoTokensBridge.interface.encodeFunctionData(
+            "finalizeERC20Withdrawal",
+            [
+              l1Token.address,
+              l2Token.address,
+              tokenHolderA.address,
+              tokenHolderA.address,
+              withdrawalAmount,
+              "0x",
+            ]
+          ),
+          0
+        );
 
-    const l2DepositCalldata = l2ERC20ExtendedTokensBridge.interface.encodeFunctionData(
-      "finalizeDeposit",
-      [
+      await assert.emits(l1LidoTokensBridge, tx, "ERC20WithdrawalFinalized", [
+        l1Token.address,
+        l2Token.address,
+        tokenHolderA.address,
+        tokenHolderA.address,
+        withdrawalAmount,
+        "0x",
+      ]);
+
+      const l1LidoTokensBridgeBalanceAfter = await l1Token.balanceOf(l1LidoTokensBridge.address);
+      const tokenHolderABalanceAfter = await l1Token.balanceOf(tokenHolderA.address);
+
+      assert.equalBN(
+        l1LidoTokensBridgeBalanceAfter,
+        l1ERC20ExtendedTokensBridgeBalanceBefore.sub(withdrawalAmount)
+      );
+
+      assert.equalBN(
+        tokenHolderABalanceAfter,
+        tokenHolderABalanceBefore.add(withdrawalAmount)
+      );
+
+      /// check that user balance is correct after depositing and withdrawal.
+      const deltaDepositWithdrawal = depositAmount.sub(withdrawalAmount);
+      assert.equalBN(
+        ctx.balances.accountABalanceBeforeDeposit,
+        tokenHolderABalanceAfter.add(deltaDepositWithdrawal)
+      );
+    })
+
+    .step("L1 -> L2 deposit via depositERC20To()", async (ctx) => {
+      const {
+        l1Token,
+        l2Token,
+        l1LidoTokensBridge,
+        l2ERC20ExtendedTokensBridge,
+        l1CrossDomainMessenger,
+      } = ctx;
+      const { accountA: tokenHolderA, accountB: tokenHolderB } = ctx.accounts;
+      const { depositAmount } = ctx.constants;
+
+      assert.notEqual(tokenHolderA.address, tokenHolderB.address);
+
+      const tokenHolderABalanceBefore = await l1Token.balanceOf(tokenHolderA.address);
+      const l1ERC20ExtendedTokensBridgeBalanceBefore = await l1Token.balanceOf(l1LidoTokensBridge.address);
+
+      ctx.balances.accountABalanceBeforeDeposit = tokenHolderABalanceBefore;
+      ctx.balances.accountBBalanceBeforeDeposit = await l2Token.balanceOf(tokenHolderB.address);
+
+      await l1Token
+        .connect(tokenHolderA.l1Signer)
+        .approve(l1LidoTokensBridge.address, depositAmount);
+
+      const tx = await l1LidoTokensBridge
+        .connect(tokenHolderA.l1Signer)
+        .depositERC20To(
+          l1Token.address,
+          l2Token.address,
+          tokenHolderB.address,
+          depositAmount,
+          200_000,
+          "0x"
+        );
+
+      const dataToSend = await packedTokenRateAndTimestamp(ctx.l1Provider, l1Token);
+
+      await assert.emits(l1LidoTokensBridge, tx, "ERC20DepositInitiated", [
         l1Token.address,
         l2Token.address,
         tokenHolderA.address,
         tokenHolderB.address,
         depositAmount,
         dataToSend,
-      ]
-    );
+      ]);
 
-    const messageNonce = await l1CrossDomainMessenger.messageNonce();
-
-    await assert.emits(l1CrossDomainMessenger, tx, "SentMessage", [
-      l2ERC20ExtendedTokensBridge.address,
-      l1LidoTokensBridge.address,
-      l2DepositCalldata,
-      messageNonce,
-      200_000,
-    ]);
-
-    assert.equalBN(
-      await l1Token.balanceOf(l1LidoTokensBridge.address),
-      l1ERC20ExtendedTokensBridgeBalanceBefore.add(depositAmount)
-    );
-
-    assert.equalBN(
-      await l1Token.balanceOf(tokenHolderA.address),
-      tokenHolderABalanceBefore.sub(depositAmount)
-    );
-  })
-
-  .step("Finalize deposit on L2", async (ctx) => {
-    const {
-      l1Token,
-      l1LidoTokensBridge,
-      l2Token,
-      l2CrossDomainMessenger,
-      l2ERC20ExtendedTokensBridge,
-    } = ctx;
-    const {
-      accountA: tokenHolderA,
-      accountB: tokenHolderB,
-      l1CrossDomainMessengerAliased,
-    } = ctx.accounts;
-    const { depositAmount } = ctx.common;
-
-    const l2TokenTotalSupplyBefore = await l2Token.totalSupply();
-    const tokenHolderBBalanceBefore = await l2Token.balanceOf(
-      tokenHolderB.address
-    );
-
-    const dataToReceive = await packedTokenRateAndTimestamp(ctx.l2Provider, l1Token);
-
-    const tx = await l2CrossDomainMessenger
-      .connect(l1CrossDomainMessengerAliased)
-      .relayMessage(
-        1,
-        l1LidoTokensBridge.address,
-        l2ERC20ExtendedTokensBridge.address,
-        0,
-        300_000,
-        l2ERC20ExtendedTokensBridge.interface.encodeFunctionData("finalizeDeposit", [
+      const l2DepositCalldata = l2ERC20ExtendedTokensBridge.interface.encodeFunctionData(
+        "finalizeDeposit",
+        [
           l1Token.address,
           l2Token.address,
           tokenHolderA.address,
           tokenHolderB.address,
           depositAmount,
-          dataToReceive,
-        ]),
-        { gasLimit: 5_000_000 }
+          dataToSend,
+        ]
       );
 
-    await assert.emits(l2ERC20ExtendedTokensBridge, tx, "DepositFinalized", [
-      l1Token.address,
-      l2Token.address,
-      tokenHolderA.address,
-      tokenHolderB.address,
-      depositAmount,
-      "0x",
-    ]);
+      const messageNonce = await l1CrossDomainMessenger.messageNonce();
 
-    assert.equalBN(
-      await l2Token.totalSupply(),
-      l2TokenTotalSupplyBefore.add(depositAmount)
-    );
-    assert.equalBN(
-      await l2Token.balanceOf(tokenHolderB.address),
-      tokenHolderBBalanceBefore.add(depositAmount)
-    );
-  })
-
-  .step("L2 -> L1 withdrawal via withdrawTo()", async (ctx) => {
-    const { l1Token, l2Token, l2ERC20ExtendedTokensBridge } = ctx;
-    const { accountA: tokenHolderA, accountB: tokenHolderB } = ctx.accounts;
-    const { withdrawalAmount } = ctx.common;
-
-    const tokenHolderBBalanceBefore = await l2Token.balanceOf(
-      tokenHolderB.address
-    );
-    const l2TotalSupplyBefore = await l2Token.totalSupply();
-
-    const tx = await l2ERC20ExtendedTokensBridge
-      .connect(tokenHolderB.l2Signer)
-      .withdrawTo(
-        l2Token.address,
-        tokenHolderA.address,
-        withdrawalAmount,
-        0,
-        "0x"
-      );
-
-    await assert.emits(l2ERC20ExtendedTokensBridge, tx, "WithdrawalInitiated", [
-      l1Token.address,
-      l2Token.address,
-      tokenHolderB.address,
-      tokenHolderA.address,
-      withdrawalAmount,
-      "0x",
-    ]);
-
-    assert.equalBN(
-      await l2Token.balanceOf(tokenHolderB.address),
-      tokenHolderBBalanceBefore.sub(withdrawalAmount)
-    );
-
-    assert.equalBN(
-      await l2Token.totalSupply(),
-      l2TotalSupplyBefore.sub(withdrawalAmount)
-    );
-  })
-
-  .step("Finalize withdrawal on L1", async (ctx) => {
-    const {
-      l1Token,
-      l1CrossDomainMessenger,
-      l1LidoTokensBridge,
-      l2CrossDomainMessenger,
-      l2Token,
-      l2ERC20ExtendedTokensBridge,
-    } = ctx;
-    const {
-      accountA: tokenHolderA,
-      accountB: tokenHolderB,
-      l1Stranger,
-    } = ctx.accounts;
-    const { withdrawalAmount } = ctx.common;
-
-    const tokenHolderABalanceBefore = await l1Token.balanceOf(
-      tokenHolderA.address
-    );
-    const l1ERC20ExtendedTokensBridgeBalanceBefore = await l1Token.balanceOf(
-      l1LidoTokensBridge.address
-    );
-
-    await l1CrossDomainMessenger
-      .connect(l1Stranger)
-      .setXDomainMessageSender(l2ERC20ExtendedTokensBridge.address);
-
-    const tx = await l1CrossDomainMessenger
-      .connect(l1Stranger)
-      .relayMessage(
+      await assert.emits(l1CrossDomainMessenger, tx, "SentMessage", [
+        l2ERC20ExtendedTokensBridge.address,
         l1LidoTokensBridge.address,
-        l2CrossDomainMessenger.address,
-        l1LidoTokensBridge.interface.encodeFunctionData(
-          "finalizeERC20Withdrawal",
-          [
+        l2DepositCalldata,
+        messageNonce,
+        200_000,
+      ]);
+
+      assert.equalBN(
+        await l1Token.balanceOf(l1LidoTokensBridge.address),
+        l1ERC20ExtendedTokensBridgeBalanceBefore.add(depositAmount)
+      );
+
+      assert.equalBN(
+        await l1Token.balanceOf(tokenHolderA.address),
+        tokenHolderABalanceBefore.sub(depositAmount)
+      );
+    })
+
+    .step("Finalize deposit on L2", async (ctx) => {
+      const {
+        l1Token,
+        l1LidoTokensBridge,
+        l2Token,
+        l2CrossDomainMessenger,
+        l2ERC20ExtendedTokensBridge,
+      } = ctx;
+      const {
+        accountA: tokenHolderA,
+        accountB: tokenHolderB,
+        l1CrossDomainMessengerAliased,
+      } = ctx.accounts;
+      const { depositAmount } = ctx.constants;
+
+      const l2TokenTotalSupplyBefore = await l2Token.totalSupply();
+      const tokenHolderBBalanceBefore = await l2Token.balanceOf(tokenHolderB.address);
+
+      const dataToReceive = await packedTokenRateAndTimestamp(ctx.l2Provider, l1Token);
+
+      const tx = await l2CrossDomainMessenger
+        .connect(l1CrossDomainMessengerAliased)
+        .relayMessage(
+          1,
+          l1LidoTokensBridge.address,
+          l2ERC20ExtendedTokensBridge.address,
+          0,
+          300_000,
+          l2ERC20ExtendedTokensBridge.interface.encodeFunctionData("finalizeDeposit", [
             l1Token.address,
             l2Token.address,
-            tokenHolderB.address,
             tokenHolderA.address,
-            withdrawalAmount,
-            "0x",
-          ]
-        ),
-        0
+            tokenHolderB.address,
+            depositAmount,
+            dataToReceive,
+          ]),
+          { gasLimit: 5_000_000 }
+        );
+
+      await assert.emits(l2ERC20ExtendedTokensBridge, tx, "DepositFinalized", [
+        l1Token.address,
+        l2Token.address,
+        tokenHolderA.address,
+        tokenHolderB.address,
+        depositAmount,
+        "0x",
+      ]);
+
+      assert.equalBN(
+        await l2Token.totalSupply(),
+        l2TokenTotalSupplyBefore.add(depositAmount)
+      );
+      assert.equalBN(
+        await l2Token.balanceOf(tokenHolderB.address),
+        tokenHolderBBalanceBefore.add(depositAmount)
+      );
+    })
+
+    .step("L2 -> L1 withdrawal via withdrawTo()", async (ctx) => {
+      const { l1Token, l2Token, l2ERC20ExtendedTokensBridge } = ctx;
+      const { accountA: tokenHolderA, accountB: tokenHolderB } = ctx.accounts;
+      const { withdrawalAmount } = ctx.constants;
+
+      const tokenHolderBBalanceBefore = await l2Token.balanceOf(
+        tokenHolderB.address
+      );
+      const l2TotalSupplyBefore = await l2Token.totalSupply();
+
+      const tx = await l2ERC20ExtendedTokensBridge
+        .connect(tokenHolderB.l2Signer)
+        .withdrawTo(
+          l2Token.address,
+          tokenHolderA.address,
+          withdrawalAmount,
+          0,
+          "0x"
+        );
+
+      await assert.emits(l2ERC20ExtendedTokensBridge, tx, "WithdrawalInitiated", [
+        l1Token.address,
+        l2Token.address,
+        tokenHolderB.address,
+        tokenHolderA.address,
+        withdrawalAmount,
+        "0x",
+      ]);
+
+      assert.equalBN(
+        await l2Token.balanceOf(tokenHolderB.address),
+        tokenHolderBBalanceBefore.sub(withdrawalAmount)
       );
 
-    await assert.emits(l1LidoTokensBridge, tx, "ERC20WithdrawalFinalized", [
-      l1Token.address,
-      l2Token.address,
-      tokenHolderB.address,
-      tokenHolderA.address,
-      withdrawalAmount,
-      "0x",
-    ]);
+      assert.equalBN(
+        await l2Token.totalSupply(),
+        l2TotalSupplyBefore.sub(withdrawalAmount)
+      );
+    })
 
-    assert.equalBN(
-      await l1Token.balanceOf(l1LidoTokensBridge.address),
-      l1ERC20ExtendedTokensBridgeBalanceBefore.sub(withdrawalAmount)
-    );
+    .step("Finalize withdrawal on L1", async (ctx) => {
+      const {
+        l1Token,
+        l1CrossDomainMessenger,
+        l1LidoTokensBridge,
+        l2CrossDomainMessenger,
+        l2Token,
+        l2ERC20ExtendedTokensBridge,
+      } = ctx;
+      const {
+        accountA: tokenHolderA,
+        accountB: tokenHolderB,
+        l1Stranger,
+      } = ctx.accounts;
+      const { depositAmount, withdrawalAmount } = ctx.constants;
 
-    assert.equalBN(
-      await l1Token.balanceOf(tokenHolderA.address),
-      tokenHolderABalanceBefore.add(withdrawalAmount)
-    );
-  })
+      const tokenHolderABalanceBefore = await l1Token.balanceOf(
+        tokenHolderA.address
+      );
+      const l1ERC20ExtendedTokensBridgeBalanceBefore = await l1Token.balanceOf(
+        l1LidoTokensBridge.address
+      );
 
-  .run();
+      await l1CrossDomainMessenger
+        .connect(l1Stranger)
+        .setXDomainMessageSender(l2ERC20ExtendedTokensBridge.address);
 
-async function ctxFactory() {
-  const networkName = env.network("TESTING_OPT_NETWORK", "mainnet");
+      const tx = await l1CrossDomainMessenger
+        .connect(l1Stranger)
+        .relayMessage(
+          l1LidoTokensBridge.address,
+          l2CrossDomainMessenger.address,
+          l1LidoTokensBridge.interface.encodeFunctionData(
+            "finalizeERC20Withdrawal",
+            [
+              l1Token.address,
+              l2Token.address,
+              tokenHolderB.address,
+              tokenHolderA.address,
+              withdrawalAmount,
+              "0x",
+            ]
+          ),
+          0
+        );
 
-  const {
-    l1Provider,
-    l2Provider,
-    l1ERC20ExtendedTokensBridgeAdmin,
-    l2ERC20ExtendedTokensBridgeAdmin,
-    ...contracts
-  } = await optimism.testing(networkName).getIntegrationTestSetup();
+      await assert.emits(l1LidoTokensBridge, tx, "ERC20WithdrawalFinalized", [
+        l1Token.address,
+        l2Token.address,
+        tokenHolderB.address,
+        tokenHolderA.address,
+        withdrawalAmount,
+        "0x",
+      ]);
 
-  const l1Snapshot = await l1Provider.send("evm_snapshot", []);
-  const l2Snapshot = await l2Provider.send("evm_snapshot", []);
+      const l1LidoTokensBridgeBalanceAfter = await l1Token.balanceOf(l1LidoTokensBridge.address);
+      const tokenHolderABalanceAfter = await l1Token.balanceOf(tokenHolderA.address);
+      const tokenHolderBBalanceAfter = await l2Token.balanceOf(tokenHolderB.address);
 
-  await optimism.testing(networkName).stubL1CrossChainMessengerContract();
+      assert.equalBN(
+        l1LidoTokensBridgeBalanceAfter,
+        l1ERC20ExtendedTokensBridgeBalanceBefore.sub(withdrawalAmount)
+      );
 
-  const accountA = testing.accounts.accountA(l1Provider, l2Provider);
-  const accountB = testing.accounts.accountB(l1Provider, l2Provider);
+      assert.equalBN(
+        tokenHolderABalanceAfter,
+        tokenHolderABalanceBefore.add(withdrawalAmount)
+      );
 
-  const depositAmount = wei`0.15 ether`;
-  const withdrawalAmount = wei`0.05 ether`;
+      /// check that user balance is correct after depositing and withdrawal.
+      const deltaDepositWithdrawal = depositAmount.sub(withdrawalAmount);
+      assert.equalBN(
+        ctx.balances.accountABalanceBeforeDeposit,
+        tokenHolderABalanceAfter.add(deltaDepositWithdrawal)
+      );
+      assert.equalBN(
+        ctx.balances.accountBBalanceBeforeDeposit,
+        tokenHolderBBalanceAfter.sub(deltaDepositWithdrawal)
+      );
+    })
 
-  await testing.setBalance(
-    await contracts.l1TokensHolder.getAddress(),
-    wei.toBigNumber(wei`1 ether`),
-    l1Provider
-  );
+    .run();
+}
 
-  await testing.setBalance(
-    await l1ERC20ExtendedTokensBridgeAdmin.getAddress(),
-    wei.toBigNumber(wei`1 ether`),
-    l1Provider
-  );
+function ctxFactory(depositAmount: BigNumber, withdrawalAmount: BigNumber) {
+  return async () => {
+    const networkName = env.network("TESTING_OPT_NETWORK", "mainnet");
+    const tokenRate = BigNumber.from('1164454276599657236');
 
-  await testing.setBalance(
-    await l2ERC20ExtendedTokensBridgeAdmin.getAddress(),
-    wei.toBigNumber(wei`1 ether`),
-    l2Provider
-  );
-
-  await contracts.l1Token
-    .connect(contracts.l1TokensHolder)
-    .transfer(accountA.l1Signer.address, wei.toBigNumber(depositAmount).mul(2));
-
-  const l1CrossDomainMessengerAliased = await testing.impersonate(
-    testing.accounts.applyL1ToL2Alias(contracts.l1CrossDomainMessenger.address),
-    l2Provider
-  );
-
-  await testing.setBalance(
-    await l1CrossDomainMessengerAliased.getAddress(),
-    wei.toBigNumber(wei`1 ether`),
-    l2Provider
-  );
-
-  return {
-    l1Provider,
-    l2Provider,
-    ...contracts,
-    accounts: {
-      accountA,
-      accountB,
-      l1Stranger: testing.accounts.stranger(l1Provider),
+    const {
+      l1Provider,
+      l2Provider,
       l1ERC20ExtendedTokensBridgeAdmin,
       l2ERC20ExtendedTokensBridgeAdmin,
-      l1CrossDomainMessengerAliased,
-    },
-    common: {
-      depositAmount,
-      withdrawalAmount,
-    },
-    snapshot: {
-      l1: l1Snapshot,
-      l2: l2Snapshot,
-    },
-  };
+      ...contracts
+    } = await optimism.testing(networkName).getIntegrationTestSetup(tokenRate);
+
+    const l1Snapshot = await l1Provider.send("evm_snapshot", []);
+    const l2Snapshot = await l2Provider.send("evm_snapshot", []);
+
+
+    await optimism.testing(networkName).stubL1CrossChainMessengerContract();
+
+    const accountA = testing.accounts.accountA(l1Provider, l2Provider);
+    const accountB = testing.accounts.accountB(l1Provider, l2Provider);
+
+    await testing.setBalance(
+      await contracts.l1TokensHolder.getAddress(),
+      wei.toBigNumber(wei`1 ether`),
+      l1Provider
+    );
+
+    await testing.setBalance(
+      await l1ERC20ExtendedTokensBridgeAdmin.getAddress(),
+      wei.toBigNumber(wei`1 ether`),
+      l1Provider
+    );
+
+    await testing.setBalance(
+      await l2ERC20ExtendedTokensBridgeAdmin.getAddress(),
+      wei.toBigNumber(wei`1 ether`),
+      l2Provider
+    );
+
+    const l1CrossDomainMessengerAliased = await testing.impersonate(
+      testing.accounts.applyL1ToL2Alias(contracts.l1CrossDomainMessenger.address),
+      l2Provider
+    );
+
+    await testing.setBalance(
+      await l1CrossDomainMessengerAliased.getAddress(),
+      wei.toBigNumber(wei`1 ether`),
+      l2Provider
+    );
+
+    await contracts.l1Token
+      .connect(contracts.l1TokensHolder)
+      .transfer(accountA.l1Signer.address, depositAmount.mul(2));
+
+    var accountABalanceBeforeDeposit = BigNumber.from(0);
+    var accountBBalanceBeforeDeposit = BigNumber.from(0);
+
+    return {
+      l1Provider,
+      l2Provider,
+      ...contracts,
+      accounts: {
+        accountA,
+        accountB,
+        l1Stranger: testing.accounts.stranger(l1Provider),
+        l1ERC20ExtendedTokensBridgeAdmin,
+        l2ERC20ExtendedTokensBridgeAdmin,
+        l1CrossDomainMessengerAliased,
+      },
+      constants: {
+        depositAmount,
+        withdrawalAmount,
+        tokenRate
+      },
+      balances: {
+        accountABalanceBeforeDeposit,
+        accountBBalanceBeforeDeposit
+      },
+      snapshot: {
+        l1: l1Snapshot,
+        l2: l2Snapshot,
+      },
+    };
+  }
 }
 
 async function packedTokenRateAndTimestamp(l1Provider: JsonRpcProvider, l1Token: ERC20WrapperStub) {
@@ -630,3 +666,33 @@ async function packedTokenRateAndTimestamp(l1Provider: JsonRpcProvider, l1Token:
   const blockTimestampStr = ethers.utils.hexZeroPad(ethers.utils.hexlify(blockTimestamp), 5);
   return ethers.utils.hexConcat([stEthPerTokenStr, blockTimestampStr]);
 }
+
+bridgingTestsSuit(
+  scenario(
+    "Optimism :: Bridging X non-rebasable token integration test",
+    ctxFactory(
+      wei.toBigNumber(wei`0.001 ether`),
+      wei.toBigNumber(wei`0.001 ether`)
+    )
+  )
+);
+
+bridgingTestsSuit(
+  scenario(
+    "Optimism :: Bridging 1 wei non-rebasable token integration test",
+    ctxFactory(
+      wei.toBigNumber(wei`1 wei`),
+      wei.toBigNumber(wei`1 wei`)
+    )
+  )
+);
+
+bridgingTestsSuit(
+  scenario(
+    "Optimism :: Bridging zero non-rebasable token integration test",
+    ctxFactory(
+      BigNumber.from('0'),
+      BigNumber.from('0')
+    )
+  )
+);

--- a/test/optimism/bridging-rebasable.integration.test.ts
+++ b/test/optimism/bridging-rebasable.integration.test.ts
@@ -242,10 +242,6 @@ function bridgingTestsSuit(scenarioInstance: ScenarioTest<ContextType>) {
       const tokenHolderABalanceBefore = await l2TokenRebasable.balanceOf(tokenHolderA.address);
       const l2TotalSupplyBefore = await l2TokenRebasable.totalSupply();
 
-      await l2TokenRebasable
-        .connect(tokenHolderA.l2Signer)
-        .approve(l2ERC20ExtendedTokensBridge.address, withdrawalAmountOfRebasableToken);
-
       const tx = await l2ERC20ExtendedTokensBridge
         .connect(tokenHolderA.l2Signer)
         .withdraw(
@@ -512,10 +508,6 @@ function bridgingTestsSuit(scenarioInstance: ScenarioTest<ContextType>) {
 
       const tokenHolderBBalanceBefore = await l2TokenRebasable.balanceOf(tokenHolderB.address);
       const l2TotalSupplyBefore = await l2TokenRebasable.totalSupply();
-
-      await l2TokenRebasable
-        .connect(tokenHolderB.l2Signer)
-        .approve(l2ERC20ExtendedTokensBridge.address, withdrawalAmountOfRebasableToken);
 
       const tx = await l2ERC20ExtendedTokensBridge
         .connect(tokenHolderB.l2Signer)

--- a/test/optimism/bridging-rebasable.integration.test.ts
+++ b/test/optimism/bridging-rebasable.integration.test.ts
@@ -96,6 +96,9 @@ function bridgingTestsSuit(scenarioInstance: ScenarioTest<ContextType>) {
         .approve(l1LidoTokensBridge.address, depositAmountOfRebasableToken);
 
       const rebasableTokenHolderBalanceBefore = await l1TokenRebasable.balanceOf(tokenHolderA.address);
+
+      ctx.balances.accountABalanceBeforeDeposit = rebasableTokenHolderBalanceBefore;
+
       const nonRebasableTokenBridgeBalanceBefore = await l1Token.balanceOf(l1LidoTokensBridge.address);
       const warappedRebasableTokenBalanceBefore = await l1TokenRebasable.balanceOf(l1Token.address);
 
@@ -144,20 +147,21 @@ function bridgingTestsSuit(scenarioInstance: ScenarioTest<ContextType>) {
 
       const rebasableTokenHolderBalanceAfter = await l1TokenRebasable.balanceOf(tokenHolderA.address);
       const nonRebasableTokenBridgeBalanceAfter = await l1Token.balanceOf(l1LidoTokensBridge.address);
-      const warappedRebasableTokenBalanceAfter = await l1TokenRebasable.balanceOf(l1Token.address);
-
+      const wrappedRebasableTokenBalanceAfter = await l1TokenRebasable.balanceOf(l1Token.address);
 
       assert.equalBN(
         rebasableTokenHolderBalanceAfter,
         rebasableTokenHolderBalanceBefore.sub(depositAmountOfRebasableToken)
       );
 
-      const balanceDelta = nonRebasableTokenBridgeBalanceAfter.sub(nonRebasableTokenBridgeBalanceBefore);
-      const oneTwoWei = BigNumber.from(depositAmountNonRebasable).sub(balanceDelta);
-      assert.isTrue(oneTwoWei.gte(0) && oneTwoWei.lte(2));
+      // during wrapping 1-2 wei can be lost
+      assert.isTrue(almostEqual(
+          depositAmountNonRebasable,
+          nonRebasableTokenBridgeBalanceAfter.sub(nonRebasableTokenBridgeBalanceBefore))
+      );
 
       assert.equalBN(
-        warappedRebasableTokenBalanceAfter,
+        wrappedRebasableTokenBalanceAfter,
         warappedRebasableTokenBalanceBefore.add(depositAmountOfRebasableToken)
       );
     })
@@ -213,13 +217,16 @@ function bridgingTestsSuit(scenarioInstance: ScenarioTest<ContextType>) {
         "0x",
       ]);
 
+      const tokenHolderABalanceAfter = await l2TokenRebasable.balanceOf(tokenHolderA.address);
+      const l2TokenRebasableTotalSupplyAfter = await l2TokenRebasable.totalSupply();
+
       assert.equalBN(
-        await l2TokenRebasable.balanceOf(tokenHolderA.address),
-        tokenHolderABalanceBefore.add(depositAmountRebasable)
+        tokenHolderABalanceBefore.add(depositAmountRebasable),
+        tokenHolderABalanceAfter
       );
       assert.equalBN(
-        await l2TokenRebasable.totalSupply(),
-        l2TokenRebasableTotalSupplyBefore.add(depositAmountRebasable)
+        l2TokenRebasableTotalSupplyBefore.add(depositAmountRebasable),
+        l2TokenRebasableTotalSupplyAfter
       );
     })
 
@@ -234,6 +241,10 @@ function bridgingTestsSuit(scenarioInstance: ScenarioTest<ContextType>) {
 
       const tokenHolderABalanceBefore = await l2TokenRebasable.balanceOf(tokenHolderA.address);
       const l2TotalSupplyBefore = await l2TokenRebasable.totalSupply();
+
+      await l2TokenRebasable
+        .connect(tokenHolderA.l2Signer)
+        .approve(l2ERC20ExtendedTokensBridge.address, withdrawalAmountOfRebasableToken);
 
       const tx = await l2ERC20ExtendedTokensBridge
         .connect(tokenHolderA.l2Signer)
@@ -256,6 +267,7 @@ function bridgingTestsSuit(scenarioInstance: ScenarioTest<ContextType>) {
       const tokenHolderABalanceAfter = await l2TokenRebasable.balanceOf(tokenHolderA.address);
       const l2TotalSupplyAfter = await l2TokenRebasable.totalSupply()
 
+      // during unwrapping 1-2 wei can be lost
       assert.isTrue(almostEqual(tokenHolderABalanceAfter, tokenHolderABalanceBefore.sub(withdrawalAmountOfRebasableToken)));
       assert.isTrue(almostEqual(l2TotalSupplyAfter, l2TotalSupplyBefore.sub(withdrawalAmountOfRebasableToken)));
     })
@@ -271,7 +283,7 @@ function bridgingTestsSuit(scenarioInstance: ScenarioTest<ContextType>) {
         l2ERC20ExtendedTokensBridge,
       } = ctx;
       const { accountA: tokenHolderA, l1Stranger } = ctx.accounts;
-      const { withdrawalAmountOfRebasableToken, tokenRate } = ctx.constants;
+      const { depositAmountOfRebasableToken, withdrawalAmountOfRebasableToken, tokenRate } = ctx.constants;
 
       const withdrawalAmountNonRebasable = nonRebasableFromRebasable(withdrawalAmountOfRebasableToken, tokenRate);
       const withdrawalAmountRebasable = rebasableFromNonRebasable(withdrawalAmountNonRebasable, tokenRate);
@@ -323,6 +335,13 @@ function bridgingTestsSuit(scenarioInstance: ScenarioTest<ContextType>) {
         tokenHolderABalanceAfter,
         tokenHolderABalanceBefore.add(withdrawalAmountRebasable)
       );
+
+      /// check that user balance is correct after depositing and withdrawal.
+      const deltaDepositWithdrawal = depositAmountOfRebasableToken.sub(withdrawalAmountOfRebasableToken);
+      assert.isTrue(almostEqual(
+        ctx.balances.accountABalanceBeforeDeposit,
+        tokenHolderABalanceAfter.add(deltaDepositWithdrawal))
+      );
     })
 
     .step("L1 -> L2 deposit via depositERC20To()", async (ctx) => {
@@ -340,12 +359,15 @@ function bridgingTestsSuit(scenarioInstance: ScenarioTest<ContextType>) {
       assert.notEqual(tokenHolderA.address, tokenHolderB.address);
 
       const { depositAmountOfRebasableToken, tokenRate } = ctx.constants;
-
       const depositAmountNonRebasable = nonRebasableFromRebasable(depositAmountOfRebasableToken, tokenRate);
 
-      const rebasableTokenHolderBalanceBefore = await l1TokenRebasable.balanceOf(tokenHolderA.address);
+      const rebasableTokenHolderABalanceBefore = await l1TokenRebasable.balanceOf(tokenHolderA.address);
       const nonRebasableTokenBridgeBalanceBefore = await l1Token.balanceOf(l1LidoTokensBridge.address);
       const warappedRebasableTokenBalanceBefore = await l1TokenRebasable.balanceOf(l1Token.address);
+
+      // save to check balance later
+      ctx.balances.accountABalanceBeforeDeposit = rebasableTokenHolderABalanceBefore;
+      ctx.balances.accountBBalanceBeforeDeposit = await l2TokenRebasable.balanceOf(tokenHolderB.address);
 
       await l1TokenRebasable
         .connect(tokenHolderA.l1Signer)
@@ -395,18 +417,20 @@ function bridgingTestsSuit(scenarioInstance: ScenarioTest<ContextType>) {
         200_000,
       ]);
 
-      const rebasableTokenHolderBalanceAfter = await l1TokenRebasable.balanceOf(tokenHolderA.address);
+      const rebasableTokenHolderABalanceAfter = await l1TokenRebasable.balanceOf(tokenHolderA.address);
       const nonRebasableTokenBridgeBalanceAfter = await l1Token.balanceOf(l1LidoTokensBridge.address);
       const warappedRebasableTokenBalanceAfter = await l1TokenRebasable.balanceOf(l1Token.address);
 
       assert.equalBN(
-        rebasableTokenHolderBalanceAfter,
-        rebasableTokenHolderBalanceBefore.sub(depositAmountOfRebasableToken)
+        rebasableTokenHolderABalanceAfter,
+        rebasableTokenHolderABalanceBefore.sub(depositAmountOfRebasableToken)
       );
 
-      const balanceDelta = nonRebasableTokenBridgeBalanceAfter.sub(nonRebasableTokenBridgeBalanceBefore);
-      const oneTwoWei = BigNumber.from(depositAmountNonRebasable).sub(balanceDelta);
-      assert.isTrue(oneTwoWei.gte(0) && oneTwoWei.lte(2));
+      // during wrapping 1-2 wei can be lost
+      assert.isTrue(almostEqual(
+        depositAmountNonRebasable,
+        nonRebasableTokenBridgeBalanceAfter.sub(nonRebasableTokenBridgeBalanceBefore))
+      );
 
       assert.equalBN(
         warappedRebasableTokenBalanceAfter,
@@ -439,10 +463,7 @@ function bridgingTestsSuit(scenarioInstance: ScenarioTest<ContextType>) {
       const dataToReceive = await packedTokenRateAndTimestamp(l2Provider, l1Token);
 
       const l2TokenRebasableTotalSupplyBefore = await l2TokenRebasable.totalSupply();
-
-      const tokenHolderBBalanceBefore = await l2TokenRebasable.balanceOf(
-        tokenHolderB.address
-      );
+      const tokenHolderBBalanceBefore = await l2TokenRebasable.balanceOf(tokenHolderB.address);
 
       const tx = await l2CrossDomainMessenger
         .connect(l1CrossDomainMessengerAliased)
@@ -492,6 +513,10 @@ function bridgingTestsSuit(scenarioInstance: ScenarioTest<ContextType>) {
       const tokenHolderBBalanceBefore = await l2TokenRebasable.balanceOf(tokenHolderB.address);
       const l2TotalSupplyBefore = await l2TokenRebasable.totalSupply();
 
+      await l2TokenRebasable
+        .connect(tokenHolderB.l2Signer)
+        .approve(l2ERC20ExtendedTokensBridge.address, withdrawalAmountOfRebasableToken);
+
       const tx = await l2ERC20ExtendedTokensBridge
         .connect(tokenHolderB.l2Signer)
         .withdrawTo(
@@ -534,7 +559,7 @@ function bridgingTestsSuit(scenarioInstance: ScenarioTest<ContextType>) {
         l1Stranger,
       } = ctx.accounts;
 
-      const { withdrawalAmountOfRebasableToken, tokenRate } = ctx.constants;
+      const { depositAmountOfRebasableToken, withdrawalAmountOfRebasableToken, tokenRate } = ctx.constants;
 
       const withdrawalAmountNonRebasable = nonRebasableFromRebasable(withdrawalAmountOfRebasableToken, tokenRate);
       const withdrawalAmountRebasable = rebasableFromNonRebasable(withdrawalAmountNonRebasable, tokenRate);
@@ -576,6 +601,7 @@ function bridgingTestsSuit(scenarioInstance: ScenarioTest<ContextType>) {
 
       const l1LidoTokensBridgeBalanceAfter = await l1Token.balanceOf(l1LidoTokensBridge.address);
       const tokenHolderABalanceAfter = await l1TokenRebasable.balanceOf(tokenHolderA.address);
+      const tokenHolderBBalanceAfter = await l2TokenRebasable.balanceOf(tokenHolderB.address);
 
       assert.equalBN(
         l1LidoTokensBridgeBalanceAfter,
@@ -586,13 +612,26 @@ function bridgingTestsSuit(scenarioInstance: ScenarioTest<ContextType>) {
         tokenHolderABalanceAfter,
         tokenHolderABalanceBefore.add(withdrawalAmountRebasable)
       );
+
+      /// check that user balance is correct after depositing and withdrawal.
+      const deltaDepositWithdrawal = depositAmountOfRebasableToken.sub(withdrawalAmountOfRebasableToken);
+      assert.isTrue(almostEqual(
+        ctx.balances.accountABalanceBeforeDeposit,
+        tokenHolderABalanceAfter.add(deltaDepositWithdrawal))
+      );
+      assert.isTrue(almostEqual(
+        ctx.balances.accountBBalanceBeforeDeposit,
+        tokenHolderBBalanceAfter.sub(deltaDepositWithdrawal))
+      );
     })
+
     .run();
 }
 
 function ctxFactory(depositAmountOfRebasableToken: BigNumber, withdrawalAmountOfRebasableToken: BigNumber) {
   return async () => {
     const networkName = env.network("TESTING_OPT_NETWORK", "mainnet");
+    const exchangeRate = BigNumber.from('1164454276599657236');
 
     const {
       l1Provider,
@@ -600,7 +639,7 @@ function ctxFactory(depositAmountOfRebasableToken: BigNumber, withdrawalAmountOf
       l1ERC20ExtendedTokensBridgeAdmin,
       l2ERC20ExtendedTokensBridgeAdmin,
       ...contracts
-    } = await optimism.testing(networkName).getIntegrationTestSetup();
+    } = await optimism.testing(networkName).getIntegrationTestSetup(exchangeRate);
 
     const l1Snapshot = await l1Provider.send("evm_snapshot", []);
     const l2Snapshot = await l2Provider.send("evm_snapshot", []);
@@ -610,8 +649,6 @@ function ctxFactory(depositAmountOfRebasableToken: BigNumber, withdrawalAmountOf
     const accountA = testing.accounts.accountA(l1Provider, l2Provider);
     const accountB = testing.accounts.accountB(l1Provider, l2Provider);
 
-    const exchangeRate = BigNumber.from('1164454276599657236');
-    const depositAmountRebasable = wei.toBigNumber(wei`0.15 ether`);
 
     await testing.setBalance(
       await contracts.l1TokensHolder.getAddress(),
@@ -631,10 +668,6 @@ function ctxFactory(depositAmountOfRebasableToken: BigNumber, withdrawalAmountOf
       l2Provider
     );
 
-    await contracts.l1TokenRebasable
-      .connect(contracts.l1TokensHolder)
-      .transfer(accountA.l1Signer.address, depositAmountRebasable);
-
     const l1CrossDomainMessengerAliased = await testing.impersonate(
       testing.accounts.applyL1ToL2Alias(contracts.l1CrossDomainMessenger.address),
       l2Provider
@@ -645,6 +678,13 @@ function ctxFactory(depositAmountOfRebasableToken: BigNumber, withdrawalAmountOf
       wei.toBigNumber(wei`1 ether`),
       l2Provider
     );
+
+    await contracts.l1TokenRebasable
+      .connect(contracts.l1TokensHolder)
+      .transfer(accountA.l1Signer.address, depositAmountOfRebasableToken.mul(2));
+
+    var accountABalanceBeforeDeposit = BigNumber.from(0);
+    var accountBBalanceBeforeDeposit = BigNumber.from(0);
 
     return {
       l1Provider,
@@ -662,6 +702,10 @@ function ctxFactory(depositAmountOfRebasableToken: BigNumber, withdrawalAmountOf
         depositAmountOfRebasableToken,
         withdrawalAmountOfRebasableToken,
         tokenRate: exchangeRate
+      },
+      balances: {
+        accountABalanceBeforeDeposit,
+        accountBBalanceBeforeDeposit
       },
       snapshot: {
         l1: l1Snapshot,
@@ -704,20 +748,20 @@ bridgingTestsSuit(
 
 bridgingTestsSuit(
   scenario(
-    "Optimism :: Bridging Zero rebasable token integration test",
+    "Optimism :: Bridging 1 wei rebasable token integration test",
     ctxFactory(
-      BigNumber.from('0'),
-      BigNumber.from('0')
+      wei.toBigNumber(wei`1 wei`),
+      wei.toBigNumber(wei`1 wei`)
     )
   )
 );
 
 bridgingTestsSuit(
   scenario(
-    "Optimism :: Bridging 1 wei rebasable token integration test",
+    "Optimism :: Bridging Zero rebasable token integration test",
     ctxFactory(
-      wei.toBigNumber(wei`1 wei`),
-      wei.toBigNumber(wei`1 wei`)
+      BigNumber.from('0'),
+      BigNumber.from('0')
     )
   )
 );

--- a/test/optimism/deposit-gas-estimation.test.ts
+++ b/test/optimism/deposit-gas-estimation.test.ts
@@ -4,6 +4,7 @@ import env from "../../utils/env";
 import { wei } from "../../utils/wei";
 import optimism from "../../utils/optimism";
 import testing, { scenario } from "../../utils/testing";
+import { BigNumber } from 'ethers'
 
 scenario("Optimism :: Bridging integration test", ctxFactory)
   .after(async (ctx) => {
@@ -135,6 +136,7 @@ scenario("Optimism :: Bridging integration test", ctxFactory)
 async function ctxFactory() {
   const networkName = env.network("TESTING_OPT_NETWORK", "mainnet");
   console.log("networkName=", networkName);
+  const exchangeRate = BigNumber.from('1164454276599657236');
 
   const {
     l1Provider,
@@ -142,7 +144,7 @@ async function ctxFactory() {
     l1ERC20ExtendedTokensBridgeAdmin,
     l2ERC20ExtendedTokensBridgeAdmin,
     ...contracts
-  } = await optimism.testing(networkName).getIntegrationTestSetup();
+  } = await optimism.testing(networkName).getIntegrationTestSetup(exchangeRate);
 
   const l1Snapshot = await l1Provider.send("evm_snapshot", []);
   const l2Snapshot = await l2Provider.send("evm_snapshot", []);

--- a/test/token/ERC20Permit.unit.test.ts
+++ b/test/token/ERC20Permit.unit.test.ts
@@ -444,9 +444,6 @@ async function tokenProxied(
       holder
     );
 
-    const premintShares = wei.toBigNumber(wei`100 ether`);
-    await rebasableProxied.connect(owner).bridgeMintShares(holder.address, premintShares);
-
     return rebasableProxied;
   }
 

--- a/test/token/ERC20Permit.unit.test.ts
+++ b/test/token/ERC20Permit.unit.test.ts
@@ -53,12 +53,6 @@ const getAccountsEIP1271 = async () => {
 
 function permitTestsSuit(unitInstance: UnitTest<ContextType>) {
   unitInstance
-
-    //   .test("wrappedToken() :: has the same address is in constructor", async (ctx) => {
-    //       const { rebasableProxied, wrappedToken } = ctx.contracts;
-    //       assert.equal(await rebasableProxied.TOKEN_TO_WRAP_FROM(), wrappedToken.address)
-    //   })
-
     .test('eip712Domain() is correct', async (ctx) => {
       const token = ctx.contracts.rebasableProxied
       const [, name, version, chainId, verifyingContract, ,] = await token.eip712Domain()

--- a/utils/optimism/testing.ts
+++ b/utils/optimism/testing.ts
@@ -46,7 +46,7 @@ export default function testing(networkName: NetworkName) {
         ...bridgeContracts,
       };
     },
-    async getIntegrationTestSetup() {
+    async getIntegrationTestSetup(tokenRate: BigNumber) {
       const hasDeployedContracts =
         testingUtils.env.USE_DEPLOYED_CONTRACTS(false);
 
@@ -56,7 +56,7 @@ export default function testing(networkName: NetworkName) {
 
       const bridgeContracts = hasDeployedContracts
         ? await loadDeployedBridges(ethProvider, optProvider)
-        : await deployTestBridge(networkName, ethProvider, optProvider);
+        : await deployTestBridge(networkName, tokenRate, ethProvider, optProvider);
 
       const [l1ERC20ExtendedTokensAdminAddress] =
         await BridgingManagement.getAdmins(bridgeContracts.l1LidoTokensBridge);
@@ -180,6 +180,7 @@ async function loadDeployedBridges(
 
 async function deployTestBridge(
   networkName: NetworkName,
+  tokenRate: BigNumber,
   ethProvider: JsonRpcProvider,
   optProvider: JsonRpcProvider
 ) {
@@ -195,7 +196,7 @@ async function deployTestBridge(
     l1TokenRebasable.address,
     "Test Token",
     "TT",
-    BigNumber.from('1164454276599657236')
+    tokenRate
   );
 
   const [ethDeployScript, optDeployScript] = await deploymentAll(
@@ -213,7 +214,7 @@ async function deployTestBridge(
       admins: { proxy: optDeployer.address, bridge: optDeployer.address },
       contractsShift: 0,
       tokenRateOracle: {
-        tokenRate: BigNumber.from('1164454276599657236'),
+        tokenRate: tokenRate,
         l1Timestamp: BigNumber.from('1000')
       }
     }


### PR DESCRIPTION
#### WHAT
Fix incorrect bridging logic: minting shares for stETH on L2 directly avoiding wstETH can bring to the situation when the user wouldn't be able to unwrap stETH back to wstETH and has to bridge wstETH from L1 again.

#### HOW
##### Deposit stETH L1->L2.
- on finalizing deposit on L2 mint wstETH for bridge
- increase the allowance for the rebaseable token to be able to wrap
- wrap to stETH
- transfer stETH shares to the user

##### Withdrawal stETH L2->L1.
- bridge unwraps stETH to wstETH
- bridge burns  wstETH 