### PR TITLE
Draft: change rate reporting approach

### DIFF
--- a/contracts/lib/DepositDataCodec.sol
+++ b/contracts/lib/DepositDataCodec.sol
@@ -31,7 +31,7 @@ library DepositDataCodec {
         }
 
         DepositData memory depositData = DepositData({
-            rate: uint96(bytes12(buffer[0:RATE_FIELD_SIZE])),
+            rate: uint128(bytes16(buffer[0:RATE_FIELD_SIZE])),
             timestamp: uint40(bytes5(buffer[RATE_FIELD_SIZE:RATE_FIELD_SIZE + TIMESTAMP_FIELD_SIZE])),
             data: buffer[RATE_FIELD_SIZE + TIMESTAMP_FIELD_SIZE:]
         });

--- a/contracts/lib/DepositDataCodec.sol
+++ b/contracts/lib/DepositDataCodec.sol
@@ -7,11 +7,11 @@ pragma solidity 0.8.10;
 /// @notice encodes and decodes DepositData for crosschain transfering.
 library DepositDataCodec {
 
-    uint8 internal constant RATE_FIELD_SIZE = 12;
+    uint8 internal constant RATE_FIELD_SIZE = 16;
     uint8 internal constant TIMESTAMP_FIELD_SIZE = 5;
 
     struct DepositData {
-        uint96 rate;
+        uint128 rate;
         uint40 timestamp;
         bytes data;
     }

--- a/contracts/lido/stubs/AccountingOracleStub.sol
+++ b/contracts/lido/stubs/AccountingOracleStub.sol
@@ -1,0 +1,32 @@
+// SPDX-FileCopyrightText: 2024 Lido <info@lido.fi>
+// SPDX-License-Identifier: GPL-3.0
+
+pragma solidity 0.8.10;
+
+import {IAccountingOracle} from "../../optimism/TokenRateAndUpdateTimestampProvider.sol";
+
+/// @dev For testing purposes.
+contract AccountingOracleStub is IAccountingOracle {
+
+    uint256 private immutable genesisTime;
+    uint256 private immutable secondsPerSlot;
+    uint256 private immutable lastProcessingRefSlot;
+
+    constructor(uint256 genesisTime_, uint256 secondsPerSlot_, uint256 lastProcessingRefSlot_) {
+        genesisTime = genesisTime_;
+        secondsPerSlot = secondsPerSlot_;
+        lastProcessingRefSlot = lastProcessingRefSlot_;
+    }
+
+    function GENESIS_TIME() external view returns (uint256) {
+        return genesisTime;
+    }
+
+    function SECONDS_PER_SLOT() external view returns (uint256) {
+        return secondsPerSlot;
+    }
+
+    function getLastProcessingRefSlot() external view returns (uint256) {
+        return lastProcessingRefSlot;
+    }
+}

--- a/contracts/optimism/L1ERC20ExtendedTokensBridge.sol
+++ b/contracts/optimism/L1ERC20ExtendedTokensBridge.sol
@@ -172,15 +172,16 @@ abstract contract L1ERC20ExtendedTokensBridge is
     /// @param data_ Optional data to forward to L2.
     /// @return encoded data in the 'wired' bytes form.
     function _encodeInputDepositData(bytes calldata data_) internal view returns (bytes memory)  {
+        (uint256 timestamp, uint256 rate) = tokenRate();
         return DepositDataCodec.encodeDepositData(DepositDataCodec.DepositData({
-            rate: uint96(_tokenRate()),
-            timestamp: uint40(block.timestamp),
+            rate: uint128(rate),
+            timestamp: uint40(timestamp),
             data: data_
         }));
     }
 
     /// @notice required to abstact a way token rate is requested.
-    function _tokenRate() virtual internal view returns (uint256);
+    function tokenRate() virtual public view returns (uint256 rate, uint256 updateTimestamp);
 
     error ErrorSenderNotEOA();
     error ErrorZeroAddressL2Bridge();

--- a/contracts/optimism/L1ERC20ExtendedTokensBridge.sol
+++ b/contracts/optimism/L1ERC20ExtendedTokensBridge.sol
@@ -172,7 +172,7 @@ abstract contract L1ERC20ExtendedTokensBridge is
     /// @param data_ Optional data to forward to L2.
     /// @return encoded data in the 'wired' bytes form.
     function _encodeInputDepositData(bytes calldata data_) internal view returns (bytes memory)  {
-        (uint256 timestamp, uint256 rate) = tokenRate();
+        (uint256 rate, uint256 timestamp) = tokenRate();
         return DepositDataCodec.encodeDepositData(DepositDataCodec.DepositData({
             rate: uint128(rate),
             timestamp: uint40(timestamp),

--- a/contracts/optimism/L1LidoTokensBridge.sol
+++ b/contracts/optimism/L1LidoTokensBridge.sol
@@ -9,14 +9,37 @@ import {Versioned} from "../utils/Versioned.sol";
 /// @author kovalgek
 /// @notice A subset of wstETH token interface of core LIDO protocol.
 interface IERC20WstETH {
-    /// @notice Get amount of wstETH for a one stETH
-    /// @return Amount of wstETH for a 1 stETH
-    function stEthPerToken() external view returns (uint256);
+    /// @notice Get amount of stETH for the givern amount of wstETH
+    /// @return Amount of stETH
+    function getStETHByWstETH(uint256 _wstETHAmount) external view returns (uint256);
+}
+
+/// @author dzhon
+/// @notice A subset of AccountingOracle interface of core LIDO protocol.
+interface IAccountingOracle {
+    /// @notice Get timetamp of the Consensus Layer genesis
+    function GENESIS_TIME() external view returns (uint256);
+    /// @notice Get seconds per single Consensus Layer slot
+    function SECONDS_PER_SLOT() external view returns (uint256);
+    /// @notice Returns the last reference slot for which processing of the report was started
+    function getLastProcessingRefSlot() external view returns (uint256);
 }
 
 /// @author kovalgek
 /// @notice Hides wstETH concept from other contracts to keep `L1ERC20ExtendedTokensBridge` reusable.
 contract L1LidoTokensBridge is L1ERC20ExtendedTokensBridge, Versioned {
+
+    /// @notice Timetamp of the Consensus Layer genesis
+    uint256 public immutable GENESIS_TIME;
+
+    /// @notice Seconds per single Consensus Layer slot
+    uint256 public immutable SECONDS_PER_SLOT;
+
+    /// @notice Address of the AccountingOracle instance
+    address public immutable ACCOUNTING_ORACLE;
+
+    /// @notice Token rate decimals to push
+    uint256 public constant TOKEN_RATE_DECIMALS = 27;
 
     /// @param messenger_ L1 messenger address being used for cross-chain communications
     /// @param l2TokenBridge_ Address of the corresponding L2 bridge
@@ -24,13 +47,15 @@ contract L1LidoTokensBridge is L1ERC20ExtendedTokensBridge, Versioned {
     /// @param l1TokenRebasable_ Address of the bridged token in the L1 chain
     /// @param l2TokenNonRebasable_ Address of the token minted on the L2 chain when token bridged
     /// @param l2TokenRebasable_ Address of the token minted on the L2 chain when token bridged
+    /// @param accountingOracle_ Address of the AccountingOracle instance to retrieve rate update timestamps
     constructor(
         address messenger_,
         address l2TokenBridge_,
         address l1TokenNonRebasable_,
         address l1TokenRebasable_,
         address l2TokenNonRebasable_,
-        address l2TokenRebasable_
+        address l2TokenRebasable_,
+        address accountingOracle_
     ) L1ERC20ExtendedTokensBridge(
         messenger_,
         l2TokenBridge_,
@@ -39,6 +64,9 @@ contract L1LidoTokensBridge is L1ERC20ExtendedTokensBridge, Versioned {
         l2TokenNonRebasable_,
         l2TokenRebasable_
     ) {
+        ACCOUNTING_ORACLE = accountingOracle_;
+        GENESIS_TIME = IAccountingOracle(ACCOUNTING_ORACLE).GENESIS_TIME();
+        SECONDS_PER_SLOT = IAccountingOracle(ACCOUNTING_ORACLE).SECONDS_PER_SLOT();
     }
 
     /// @notice Initializes the contract from scratch.
@@ -56,7 +84,11 @@ contract L1LidoTokensBridge is L1ERC20ExtendedTokensBridge, Versioned {
         _initializeContractVersionTo(2);
     }
 
-    function _tokenRate() override internal view returns (uint256) {
-        return IERC20WstETH(L1_TOKEN_NON_REBASABLE).stEthPerToken();
+    function tokenRate() override public view returns (uint256 rate, uint256 updateTimestamp) {
+        rate = IERC20WstETH(L1_TOKEN_NON_REBASABLE).getStETHByWstETH(10 ** TOKEN_RATE_DECIMALS);
+
+        updateTimestamp = GENESIS_TIME + SECONDS_PER_SLOT * IAccountingOracle(
+            ACCOUNTING_ORACLE
+        ).getLastProcessingRefSlot();
     }
 }

--- a/contracts/optimism/L1LidoTokensBridge.sol
+++ b/contracts/optimism/L1LidoTokensBridge.sol
@@ -5,41 +5,11 @@ pragma solidity 0.8.10;
 
 import {L1ERC20ExtendedTokensBridge} from "./L1ERC20ExtendedTokensBridge.sol";
 import {Versioned} from "../utils/Versioned.sol";
-
-/// @author kovalgek
-/// @notice A subset of wstETH token interface of core LIDO protocol.
-interface IERC20WstETH {
-    /// @notice Get amount of stETH for the givern amount of wstETH
-    /// @return Amount of stETH
-    function getStETHByWstETH(uint256 _wstETHAmount) external view returns (uint256);
-}
-
-/// @author dzhon
-/// @notice A subset of AccountingOracle interface of core LIDO protocol.
-interface IAccountingOracle {
-    /// @notice Get timetamp of the Consensus Layer genesis
-    function GENESIS_TIME() external view returns (uint256);
-    /// @notice Get seconds per single Consensus Layer slot
-    function SECONDS_PER_SLOT() external view returns (uint256);
-    /// @notice Returns the last reference slot for which processing of the report was started
-    function getLastProcessingRefSlot() external view returns (uint256);
-}
+import {TokenRateAndUpdateTimestampProvider} from "./TokenRateAndUpdateTimestampProvider.sol";
 
 /// @author kovalgek
 /// @notice Hides wstETH concept from other contracts to keep `L1ERC20ExtendedTokensBridge` reusable.
-contract L1LidoTokensBridge is L1ERC20ExtendedTokensBridge, Versioned {
-
-    /// @notice Timetamp of the Consensus Layer genesis
-    uint256 public immutable GENESIS_TIME;
-
-    /// @notice Seconds per single Consensus Layer slot
-    uint256 public immutable SECONDS_PER_SLOT;
-
-    /// @notice Address of the AccountingOracle instance
-    address public immutable ACCOUNTING_ORACLE;
-
-    /// @notice Token rate decimals to push
-    uint256 public constant TOKEN_RATE_DECIMALS = 27;
+contract L1LidoTokensBridge is L1ERC20ExtendedTokensBridge, TokenRateAndUpdateTimestampProvider, Versioned {
 
     /// @param messenger_ L1 messenger address being used for cross-chain communications
     /// @param l2TokenBridge_ Address of the corresponding L2 bridge
@@ -63,11 +33,10 @@ contract L1LidoTokensBridge is L1ERC20ExtendedTokensBridge, Versioned {
         l1TokenRebasable_,
         l2TokenNonRebasable_,
         l2TokenRebasable_
-    ) {
-        ACCOUNTING_ORACLE = accountingOracle_;
-        GENESIS_TIME = IAccountingOracle(ACCOUNTING_ORACLE).GENESIS_TIME();
-        SECONDS_PER_SLOT = IAccountingOracle(ACCOUNTING_ORACLE).SECONDS_PER_SLOT();
-    }
+    ) TokenRateAndUpdateTimestampProvider(
+        l1TokenNonRebasable_,
+        accountingOracle_
+    ) {}
 
     /// @notice Initializes the contract from scratch.
     /// @param admin_ Address of the account to grant the DEFAULT_ADMIN_ROLE
@@ -85,10 +54,6 @@ contract L1LidoTokensBridge is L1ERC20ExtendedTokensBridge, Versioned {
     }
 
     function tokenRate() override public view returns (uint256 rate, uint256 updateTimestamp) {
-        rate = IERC20WstETH(L1_TOKEN_NON_REBASABLE).getStETHByWstETH(10 ** TOKEN_RATE_DECIMALS);
-
-        updateTimestamp = GENESIS_TIME + SECONDS_PER_SLOT * IAccountingOracle(
-            ACCOUNTING_ORACLE
-        ).getLastProcessingRefSlot();
+        return getTokenRateAndUpdateTimestamp();
     }
 }

--- a/contracts/optimism/OpStackTokenRatePusher.sol
+++ b/contracts/optimism/OpStackTokenRatePusher.sol
@@ -6,25 +6,15 @@ pragma solidity 0.8.10;
 import {ERC165} from "@openzeppelin/contracts/utils/introspection/ERC165.sol";
 import {CrossDomainEnabled} from "./CrossDomainEnabled.sol";
 import {ITokenRatePusher} from "../lido/interfaces/ITokenRatePusher.sol";
-import {IERC20WstETH} from "./L1LidoTokensBridge.sol";
 import {ITokenRateUpdatable} from "../optimism/interfaces/ITokenRateUpdatable.sol";
-
-/// @author dzhon
-/// @notice Extracts of the L1ERC20ExtendedTokensBridge contract to support token rate retrieving
-interface IL1ERC20ExtendedTokensBridge {
-    /// @notice returns token rate and its update timestamp
-    function tokenRate() external view returns (uint256 rate, uint256 updateTimestamp);
-}
+import {TokenRateAndUpdateTimestampProvider} from "./TokenRateAndUpdateTimestampProvider.sol";
 
 /// @author kovalgek
 /// @notice Pushes token rate to L2 Oracle.
-contract OpStackTokenRatePusher is CrossDomainEnabled, ERC165, ITokenRatePusher {
+contract OpStackTokenRatePusher is ERC165, CrossDomainEnabled, TokenRateAndUpdateTimestampProvider, ITokenRatePusher {
 
     /// @notice Oracle address on L2 for receiving token rate.
     address public immutable L2_TOKEN_RATE_ORACLE;
-
-    /// @notice L1 token bridge
-    address public immutable L1_TOKEN_BRIDGE;
 
     /// @notice Gas limit for L2 required to finish pushing token rate on L2 side.
     ///         Client pays for gas on L2 by burning it on L1.
@@ -34,23 +24,24 @@ contract OpStackTokenRatePusher is CrossDomainEnabled, ERC165, ITokenRatePusher 
     uint32 public immutable L2_GAS_LIMIT_FOR_PUSHING_TOKEN_RATE;
 
     /// @param messenger_ L1 messenger address being used for cross-chain communications
-    /// @param l1TokenBridge_ L1 token bridge address
+    /// @param wstETH_ L1 token bridge address
+    /// @param accountingOracle_ L1 token bridge address
     /// @param tokenRateOracle_ Oracle address on L2 for receiving token rate.
     /// @param l2GasLimitForPushingTokenRate_ Gas limit required to complete pushing token rate on L2.
     constructor(
         address messenger_,
-        address l1TokenBridge_,
+        address wstETH_,
+        address accountingOracle_,
         address tokenRateOracle_,
         uint32 l2GasLimitForPushingTokenRate_
-    ) CrossDomainEnabled(messenger_) {
-        L1_TOKEN_BRIDGE = l1TokenBridge_;
+    ) CrossDomainEnabled(messenger_) TokenRateAndUpdateTimestampProvider(wstETH_, accountingOracle_) {
         L2_TOKEN_RATE_ORACLE = tokenRateOracle_;
         L2_GAS_LIMIT_FOR_PUSHING_TOKEN_RATE = l2GasLimitForPushingTokenRate_;
     }
 
     /// @inheritdoc ITokenRatePusher
     function pushTokenRate() external {
-        (uint256 rate, uint256 updateTimestamp) = IL1ERC20ExtendedTokensBridge(L1_TOKEN_BRIDGE).tokenRate();
+        (uint256 rate, uint256 updateTimestamp) = getTokenRateAndUpdateTimestamp();
 
         bytes memory message = abi.encodeWithSelector(ITokenRateUpdatable.updateRate.selector, rate, updateTimestamp);
 

--- a/contracts/optimism/TokenRateAndUpdateTimestampProvider.sol
+++ b/contracts/optimism/TokenRateAndUpdateTimestampProvider.sol
@@ -1,0 +1,60 @@
+// SPDX-FileCopyrightText: 2024 Lido <info@lido.fi>
+// SPDX-License-Identifier: GPL-3.0
+
+pragma solidity 0.8.10;
+
+/// @author dzhon
+/// @notice A subset of AccountingOracle interface of core LIDO protocol.
+interface IAccountingOracle {
+    /// @notice Get timestamp of the Consensus Layer genesis
+    function GENESIS_TIME() external view returns (uint256);
+    /// @notice Get seconds per single Consensus Layer slot
+    function SECONDS_PER_SLOT() external view returns (uint256);
+    /// @notice Returns the last reference slot for which processing of the report was started
+    function getLastProcessingRefSlot() external view returns (uint256);
+}
+
+/// @author kovalgek
+/// @notice A subset of wstETH token interface of core LIDO protocol.
+interface IERC20WstETH {
+    /// @notice Get amount of stETH for a given amount of wstETH
+    /// @param wstETHAmount_ amount of wstETH
+    /// @return Amount of stETH for a given wstETH amount
+    function getStETHByWstETH(uint256 wstETHAmount_) external view returns (uint256);
+}
+
+/// @author kovalgek
+/// @notice Provides token rate and update timestamp.
+abstract contract TokenRateAndUpdateTimestampProvider {
+
+    /// @notice Non-rebasable token of Core Lido procotol.
+    address public immutable WSTETH;
+
+    /// @notice Address of the AccountingOracle instance
+    address public immutable ACCOUNTING_ORACLE;
+
+    /// @notice Timetamp of the Consensus Layer genesis
+    uint256 public immutable GENESIS_TIME;
+
+    /// @notice Seconds per single Consensus Layer slot
+    uint256 public immutable SECONDS_PER_SLOT;
+
+    /// @notice Token rate decimals to push
+    uint256 public constant TOKEN_RATE_DECIMALS = 27;
+
+    constructor(address wstETH_, address accountingOracle_) {
+        WSTETH = wstETH_;
+        ACCOUNTING_ORACLE = accountingOracle_;
+        GENESIS_TIME = IAccountingOracle(ACCOUNTING_ORACLE).GENESIS_TIME();
+        SECONDS_PER_SLOT = IAccountingOracle(ACCOUNTING_ORACLE).SECONDS_PER_SLOT();
+    }
+
+    function getTokenRateAndUpdateTimestamp() internal view returns (uint256 rate, uint256 updateTimestamp) {
+        rate = IERC20WstETH(WSTETH).getStETHByWstETH(10 ** TOKEN_RATE_DECIMALS);
+
+        /// @dev github.com/ethereum/consensus-specs/blob/dev/specs/bellatrix/beacon-chain.md#compute_timestamp_at_slot
+        updateTimestamp = GENESIS_TIME + SECONDS_PER_SLOT * IAccountingOracle(
+            ACCOUNTING_ORACLE
+        ).getLastProcessingRefSlot();
+    }
+}

--- a/contracts/optimism/TokenRateOracle.sol
+++ b/contracts/optimism/TokenRateOracle.sol
@@ -149,7 +149,7 @@ contract TokenRateOracle is CrossDomainEnabled, ITokenRateOracle, Versioned {
         /// by the AccountingOracle report
         if (rateUpdateL1Timestamp_ == tokenRateData.rateUpdateL1Timestamp) {
             _loadTokenRateData().value.rateReceivedL2Timestamp = uint64(block.timestamp);
-            emit RateReceivedUpdated(block.timestamp);
+            emit RateReceivedTimestampUpdated(block.timestamp);
             return;
         }
 
@@ -267,7 +267,7 @@ contract TokenRateOracle is CrossDomainEnabled, ITokenRateOracle, Versioned {
     }
 
     event RateUpdated(uint256 tokenRate_, uint256 indexed rateL1Timestamp_);
-    event RateReceivedUpdated(uint256 indexed rateReceivedL2Timestamp);
+    event RateReceivedTimestampUpdated(uint256 indexed rateReceivedL2Timestamp);
     event DormantTokenRateUpdateIgnored(uint256 indexed newRateL1Timestamp_, uint256 indexed currentRateL1Timestamp_);
     event TokenRateL1TimestampIsInFuture(uint256 tokenRate_, uint256 indexed rateL1Timestamp_);
 

--- a/contracts/optimism/TokenRateOracle.sol
+++ b/contracts/optimism/TokenRateOracle.sol
@@ -154,7 +154,7 @@ contract TokenRateOracle is CrossDomainEnabled, ITokenRateOracle, Versioned {
         }
 
         /// @dev allow token rate to be within some configurable range that depens on time it wasn't updated.
-        if ((tokenRate_ != tokenRateData.tokenRate) &&!_isTokenRateWithinAllowedRange(
+        if ((tokenRate_ != tokenRateData.tokenRate) && !_isTokenRateWithinAllowedRange(
                 tokenRateData.tokenRate,
                 tokenRate_,
                 tokenRateData.rateUpdateL1Timestamp,

--- a/contracts/optimism/interfaces/ITokenRateUpdatable.sol
+++ b/contracts/optimism/interfaces/ITokenRateUpdatable.sol
@@ -8,6 +8,6 @@ pragma solidity 0.8.10;
 interface ITokenRateUpdatable {
     /// @notice Updates token rate.
     /// @param tokenRate_ wstETH/stETH token rate.
-    /// @param rateL1Timestamp_ L1 time when rate was pushed on L1 side.
-    function updateRate(uint256 tokenRate_, uint256 rateL1Timestamp_) external;
+    /// @param rateUpdateL1Timestamp_ L1 time when rate was updated on L1 side.
+    function updateRate(uint256 tokenRate_, uint256 rateUpdateL1Timestamp_) external;
 }

--- a/contracts/stubs/ERC20BridgedStub.sol
+++ b/contracts/stubs/ERC20BridgedStub.sol
@@ -13,7 +13,7 @@ contract ERC20BridgedStub is IERC20Bridged, ERC20 {
     constructor(string memory name_, string memory symbol_)
         ERC20(name_, symbol_)
     {
-        _mint(msg.sender, 1000000 * 10**18);
+        _mint(msg.sender, 1000000 * 10**40);
     }
 
     function setBridge(address bridge_) external {

--- a/contracts/stubs/ERC20WrapperStub.sol
+++ b/contracts/stubs/ERC20WrapperStub.sol
@@ -6,7 +6,7 @@ pragma solidity 0.8.10;
 import {IERC20Bridged} from "../token/ERC20Bridged.sol";
 import {ERC20} from "@openzeppelin/contracts/token/ERC20/ERC20.sol";
 import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
-import {IERC20WstETH} from "../optimism/L1LidoTokensBridge.sol";
+import {IERC20WstETH} from "../optimism/TokenRateAndUpdateTimestampProvider.sol";
 import {IERC20Wrapper} from "../token/interfaces/IERC20Wrapper.sol";
 
 /// @dev represents wstETH on L1. For testing purposes.
@@ -15,19 +15,20 @@ contract ERC20WrapperStub is IERC20Wrapper, IERC20WstETH, ERC20 {
     IERC20 public stETH;
     address public bridge;
     uint256 public tokensRate;
+    uint256 private constant DECIMALS = 27;
 
     constructor(IERC20 stETH_, string memory name_, string memory symbol_, uint256 tokensRate_)
         ERC20(name_, symbol_)
     {
         stETH = stETH_;
         tokensRate = tokensRate_;
-        _mint(msg.sender, 1000000 * 10**18);
+        _mint(msg.sender, 1000000 * 10**DECIMALS);
     }
 
     function wrap(uint256 _stETHAmount) external returns (uint256) {
         require(_stETHAmount > 0, "wstETH: can't wrap zero stETH");
 
-        uint256 wstETHAmount = (_stETHAmount * (10 ** uint256(decimals()))) / tokensRate;
+        uint256 wstETHAmount = (_stETHAmount * (10 ** DECIMALS)) / tokensRate;
 
         _mint(msg.sender, wstETHAmount);
         stETH.transferFrom(msg.sender, address(this), _stETHAmount);
@@ -38,7 +39,7 @@ contract ERC20WrapperStub is IERC20Wrapper, IERC20WstETH, ERC20 {
     function unwrap(uint256 _wstETHAmount) external returns (uint256) {
         require(_wstETHAmount > 0, "wstETH: zero amount unwrap not allowed");
 
-        uint256 stETHAmount = (_wstETHAmount * tokensRate) / (10 ** uint256(decimals()));
+        uint256 stETHAmount = (_wstETHAmount * tokensRate) / (10 ** DECIMALS);
 
         _burn(msg.sender, _wstETHAmount);
         stETH.transfer(msg.sender, stETHAmount);
@@ -47,6 +48,6 @@ contract ERC20WrapperStub is IERC20Wrapper, IERC20WstETH, ERC20 {
     }
 
     function getStETHByWstETH(uint256 _wstETHAmount) external view returns (uint256) {
-        return (tokensRate * 10**27) / _wstETHAmount;
+        return (tokensRate * 10**DECIMALS) / _wstETHAmount;
     }
 }

--- a/contracts/stubs/ERC20WrapperStub.sol
+++ b/contracts/stubs/ERC20WrapperStub.sol
@@ -46,7 +46,7 @@ contract ERC20WrapperStub is IERC20Wrapper, IERC20WstETH, ERC20 {
         return stETHAmount;
     }
 
-    function stEthPerToken() external view returns (uint256) {
-        return tokensRate;
+    function getStETHByWstETH(uint256 _wstETHAmount) external view returns (uint256) {
+        return (tokensRate * 10**27) / _wstETHAmount;
     }
 }

--- a/scripts/optimism/deploy-oracle.ts
+++ b/scripts/optimism/deploy-oracle.ts
@@ -28,6 +28,7 @@ async function main() {
         .deploymentOracle(networkName, { logger: console })
         .oracleDeployScript(
             deploymentConfig.l1Token,
+            deploymentConfig.accountingOracle,
             deploymentConfig.l2GasLimitForPushingTokenRate,
             deploymentConfig.tokenRateOutdatedDelay,
             {
@@ -48,7 +49,7 @@ async function main() {
                 tokenRateOracle: {
                     maxAllowedL2ToL1ClockLag: 86400,
                     maxAllowedTokenRateDeviationPerDay: 500,
-                    tokenRate: 1164454276599657236,
+                    tokenRate: 1164454276599657236000000000,
                     l1Timestamp: blockTimestamp
                 }
             }

--- a/test/bridge-executor/optimism.integration.test.ts
+++ b/test/bridge-executor/optimism.integration.test.ts
@@ -7,6 +7,7 @@ import {
   OptimismBridgeExecutor__factory,
   ERC20BridgedPermit__factory,
   ERC20WrapperStub__factory,
+  AccountingOracleStub__factory
 } from "../../typechain";
 import { wei } from "../../utils/wei";
 import optimism from "../../utils/optimism";
@@ -218,8 +219,10 @@ async function ctxFactory() {
     l1Token.address,
     "Test Token",
     "TT",
-    BigNumber.from('1164454276599657236')
+    BigNumber.from('1164454276599657236000000000')
   );
+
+  const accountingOracle = await new AccountingOracleStub__factory(l1Deployer).deploy(1,2,3);
 
   const optAddresses = optimism.addresses(networkName);
   const testingOnDeployedContracts = testing.env.USE_DEPLOYED_CONTRACTS(false);
@@ -244,6 +247,7 @@ async function ctxFactory() {
   ).deployAllScript(
     l1Token.address,
     l1TokenRebasable.address,
+    accountingOracle.address,
     {
       deployer: l1Deployer,
       admins: {
@@ -260,8 +264,8 @@ async function ctxFactory() {
       },
       contractsShift: 0,
       tokenRateOracle: {
-        tokenRate:10,
-        l1Timestamp:2
+        tokenRate: BigNumber.from(10),
+        l1Timestamp:BigNumber.from(2)
       }
     }
   );

--- a/test/optimism/L2ERC20ExtendedTokensBridge.unit.test.ts
+++ b/test/optimism/L2ERC20ExtendedTokensBridge.unit.test.ts
@@ -285,17 +285,24 @@ unit("Optimism:: L2ERC20ExtendedTokensBridge", ctxFactory)
 
     const amountToDepositNonRebasable = wei`1 ether`;
 
+    // wrap on L2
     const amountToWithdrawRebasable = rebasableFromNonRebasableL2(
       wei.toBigNumber(amountToDepositNonRebasable),
       tokenRateDecimals,
       exchangeRate
     );
 
+    // unwrap on L2
     const amountReceivedWithdrawNonRebasable = nonRebasableFromRebasableL2(
       amountToWithdrawRebasable,
       tokenRateDecimals,
       exchangeRate
     );
+
+    console.log("input:        amountToDepositNonRebasable=",amountToDepositNonRebasable);
+    console.log("wrap on L2: amountToWithdrawRebasable=",amountToWithdrawRebasable);
+    console.log("unwrap on L2: amountReceivedWithdrawNonRebasable=",amountReceivedWithdrawNonRebasable);
+
 
     const l1Gas = wei`1 wei`;
     const data = "0xdeadbeaf";
@@ -354,19 +361,13 @@ unit("Optimism:: L2ERC20ExtendedTokensBridge", ctxFactory)
       l1Gas,
     ]);
 
-    console.log("amountToWithdraw=",amountToWithdrawRebasable);
-
-    console.log("recipientBalanceBefore=",recipientBalanceBefore);
-    console.log("after=",await l2TokenRebasable.balanceOf(deployer.address));
+    console.log("rebasable on L2 recipientBalanceBefore=",recipientBalanceBefore);
+    console.log("rebasable on L2 recipientBalanceAfter=",await l2TokenRebasable.balanceOf(recipient.address));
 
     assert.equalBN(
       await l2TokenRebasable.balanceOf(deployer.address),
       recipientBalanceBefore.sub(amountToWithdrawRebasable)
     );
-
-    console.log("await l2TokenRebasable.totalSupply()=",await l2TokenRebasable.totalSupply());
-    console.log("totalSupplyBefore=",totalSupplyBefore);
-    // console.log("amountToWithdraw=",amountToWithdraw);
 
     assert.isTrue(almostEqual(
       await l2TokenRebasable.totalSupply(),

--- a/test/optimism/L2ERC20ExtendedTokensBridge.unit.test.ts
+++ b/test/optimism/L2ERC20ExtendedTokensBridge.unit.test.ts
@@ -1,6 +1,6 @@
 import hre, { ethers } from "hardhat";
 import { BigNumber } from "ethers";
-import { getContractAddress } from "ethers/lib/utils";
+import { predictAddresses } from "../../utils/testing/helpers";
 import { assert } from "chai";
 import { SignerWithAddress } from "@nomiclabs/hardhat-ethers/signers";
 import { JsonRpcProvider } from "@ethersproject/providers";
@@ -1097,9 +1097,9 @@ async function ctxFactory() {
   const [deployer, stranger, recipient, l1TokenBridgeEOA] =
     await hre.ethers.getSigners();
 
-  const decimals = 18;
+  const decimals = 27;
   const decimalsBN = BigNumber.from(10).pow(decimals);
-  const exchangeRate = BigNumber.from('1164454276599657236')
+  const exchangeRate = BigNumber.from('1164454276599657236000000000')
 
   const l2MessengerStub = await new CrossDomainMessengerStub__factory(
     deployer
@@ -1240,25 +1240,10 @@ async function ctxFactory() {
   };
 }
 
-async function predictAddresses(account: SignerWithAddress, txsCount: number) {
-  const currentNonce = await account.getTransactionCount();
-
-  const res: string[] = [];
-  for (let i = 0; i < txsCount; ++i) {
-    res.push(
-      getContractAddress({
-        from: account.address,
-        nonce: currentNonce + i,
-      })
-    );
-  }
-  return res;
-}
-
 async function packedTokenRateAndTimestamp(provider: JsonRpcProvider, tokenRate: BigNumber) {
   const blockNumber = await provider.getBlockNumber();
   const blockTimestamp = (await provider.getBlock(blockNumber)).timestamp;
-  const stEthPerTokenStr = ethers.utils.hexZeroPad(tokenRate.toHexString(), 12);
+  const stEthPerTokenStr = ethers.utils.hexZeroPad(tokenRate.toHexString(), 16);
   const blockTimestampStr = ethers.utils.hexZeroPad(ethers.utils.hexlify(blockTimestamp), 5);
   return ethers.utils.hexConcat([stEthPerTokenStr, blockTimestampStr]);
 }
@@ -1284,7 +1269,7 @@ async function pushTokenRate(ctx: ContextType) {
 
 async function getL2TokenBridgeImpl(deployer: SignerWithAddress, l1TokenBridge: string) {
   const decimals = 18;
-  const exchangeRate = BigNumber.from('1164454276599657236')
+  const exchangeRate = BigNumber.from('1164454276599657236000000000')
 
   const l2MessengerStub = await new CrossDomainMessengerStub__factory(
     deployer

--- a/test/optimism/OpStackTokenRatePusher.unit.test.ts
+++ b/test/optimism/OpStackTokenRatePusher.unit.test.ts
@@ -3,7 +3,7 @@ import { assert } from "chai";
 import { BigNumber } from 'ethers'
 import { unit } from "../../utils/testing";
 import { wei } from "../../utils/wei";
-import { getInterfaceID } from "../../utils/testing/helpers";
+import { getInterfaceID, getExchangeRate } from "../../utils/testing/helpers";
 import {
   OpStackTokenRatePusher__factory,
   CrossDomainMessengerStub__factory,
@@ -61,7 +61,11 @@ async function ctxFactory() {
   /// constants
   /// ---------------------------
   const [deployer, bridge, stranger, tokenRateOracle, l1TokenBridgeEOA] = await ethers.getSigners();
-  const tokenRate = BigNumber.from('1164454276599657236000000000');
+  const totalPooledEther = BigNumber.from('9309904612343950493629678');
+  const totalShares = BigNumber.from('7975822843597609202337218');
+  const tokenRateDecimals = BigNumber.from(27);
+  const tokenRate = getExchangeRate(tokenRateDecimals, totalPooledEther, totalShares);
+
   const genesisTime = BigNumber.from(1);
   const secondsPerSlot = BigNumber.from(2);
   const lastProcessingRefSlot = BigNumber.from(3);
@@ -84,7 +88,8 @@ async function ctxFactory() {
     l1TokenRebasableStub.address,
     "L1 Token Non Rebasable",
     "L1NR",
-    tokenRate
+    totalPooledEther,
+    totalShares
   );
 
   const accountingOracle = await new AccountingOracleStub__factory(deployer).deploy(

--- a/test/optimism/TokenRateNotifier.unit.test.ts
+++ b/test/optimism/TokenRateNotifier.unit.test.ts
@@ -85,17 +85,16 @@ unit("TokenRateNotifier", ctxFactory)
 
       const {
         opStackTokenRatePusher
-      } = await getOpStackTokenRatePusher
-        (
-          tokenRate,
-          genesisTime,
-          secondsPerSlot,
-          lastProcessingRefSlot,
-          deployer,
-          owner,
-          tokenRateOracle,
-          l2GasLimitForPushingTokenRate
-        );
+      } = await createContracts(
+        tokenRate,
+        genesisTime,
+        secondsPerSlot,
+        lastProcessingRefSlot,
+        deployer,
+        owner,
+        tokenRateOracle,
+        l2GasLimitForPushingTokenRate
+      );
 
       await tokenRateNotifier
         .connect(ctx.accounts.owner)
@@ -244,7 +243,37 @@ unit("TokenRateNotifier", ctxFactory)
 
   .run();
 
-async function getOpStackTokenRatePusher(
+async function ctxFactory() {
+  const [deployer, owner, stranger, tokenRateOracle] = await ethers.getSigners();
+  const tokenRate = BigNumber.from('1164454276599657236000000000');
+  const l2GasLimitForPushingTokenRate = 300_000;
+  const genesisTime = BigNumber.from(1);
+  const secondsPerSlot = BigNumber.from(2);
+  const lastProcessingRefSlot = BigNumber.from(3);
+
+  const {
+    tokenRateNotifier,
+    opStackTokenRatePusher,
+    l1MessengerStub
+  } = await createContracts(
+    tokenRate,
+    genesisTime,
+    secondsPerSlot,
+    lastProcessingRefSlot,
+    deployer,
+    owner,
+    tokenRateOracle,
+    l2GasLimitForPushingTokenRate
+  );
+
+  return {
+    accounts: { deployer, owner, stranger, tokenRateOracle },
+    contracts: { tokenRateNotifier, opStackTokenRatePusher, l1MessengerStub },
+    constants: { l2GasLimitForPushingTokenRate, tokenRate, genesisTime, secondsPerSlot, lastProcessingRefSlot }
+  };
+}
+
+async function createContracts(
   tokenRate: BigNumber,
   genesisTime: BigNumber,
   secondsPerSlot: BigNumber,
@@ -293,35 +322,5 @@ async function getOpStackTokenRatePusher(
     accountingOracle,
     l1MessengerStub,
     tokenRate
-  };
-}
-
-async function ctxFactory() {
-  const [deployer, owner, stranger, tokenRateOracle] = await ethers.getSigners();
-  const tokenRate = BigNumber.from('1164454276599657236000000000');
-  const l2GasLimitForPushingTokenRate = 300_000;
-  const genesisTime = BigNumber.from(1);
-  const secondsPerSlot = BigNumber.from(2);
-  const lastProcessingRefSlot = BigNumber.from(3);
-
-  const {
-    tokenRateNotifier,
-    opStackTokenRatePusher,
-    l1MessengerStub
-  } = await getOpStackTokenRatePusher(
-    tokenRate,
-    genesisTime,
-    secondsPerSlot,
-    lastProcessingRefSlot,
-    deployer,
-    owner,
-    tokenRateOracle,
-    l2GasLimitForPushingTokenRate
-  );
-
-  return {
-    accounts: { deployer, owner, stranger, tokenRateOracle },
-    contracts: { tokenRateNotifier, opStackTokenRatePusher, l1MessengerStub },
-    constants: { l2GasLimitForPushingTokenRate, tokenRate, genesisTime, secondsPerSlot, lastProcessingRefSlot }
   };
 }

--- a/test/optimism/TokenRateOracle.unit.test.ts
+++ b/test/optimism/TokenRateOracle.unit.test.ts
@@ -210,7 +210,7 @@ unit("TokenRateOracle", ctxFactory)
 
     const updatedAt = await getContractTransactionTimestamp(ctx.provider, tx);
 
-    await assert.emits(tokenRateOracle, tx, "RateReceivedUpdated", [updatedAt]);
+    await assert.emits(tokenRateOracle, tx, "RateReceivedTimestampUpdated", [updatedAt]);
 
     const {
       roundId_,

--- a/test/optimism/TokenRateOracle.unit.test.ts
+++ b/test/optimism/TokenRateOracle.unit.test.ts
@@ -425,14 +425,16 @@ unit("TokenRateOracle", ctxFactory)
   .run();
 
 async function ctxFactory() {
-  const [deployer, bridge, stranger, l1TokenBridgeEOA] = await hre.ethers.getSigners();
-
+  /// ---------------------------
+  /// constants
+  /// ---------------------------
   const decimals = 27;
   const provider = await hre.ethers.provider;
   const tokenRate = BigNumber.from('1164454276599657236000000000'); // value taken from real contact on 23.04.24
   const tokenRateOutdatedDelay = BigNumber.from(86400);             // 1 day
   const maxAllowedL2ToL1ClockLag = BigNumber.from(86400 * 2);       // 2 days
   const maxAllowedTokenRateDeviationPerDay = BigNumber.from(500);   // 5%
+  const [deployer, bridge, stranger, l1TokenBridgeEOA] = await hre.ethers.getSigners();
 
   const l2MessengerStub = await new CrossDomainMessengerStub__factory(deployer)
     .deploy({ value: wei.toBigNumber(wei`1 ether`) });
@@ -440,6 +442,9 @@ async function ctxFactory() {
 
   const rateL1Timestamp = await getBlockTimestamp(provider, 0);
 
+  /// ---------------------------
+  /// contracts
+  /// ---------------------------
   const { tokenRateOracle, blockTimestampOfDeployment } = await tokenRateOracleUnderProxy(
     deployer,
     l2MessengerStub.address,

--- a/test/optimism/_launch.test.ts
+++ b/test/optimism/_launch.test.ts
@@ -58,7 +58,7 @@ async function ctxFactory() {
 
   const { l1Provider, l2Provider, l1LidoTokensBridge } = await optimism
     .testing(networkName)
-    .getIntegrationTestSetup(BigNumber.from('1164454276599657236'));
+    .getIntegrationTestSetup(BigNumber.from('1164454276599657236000000000'));
 
   const hasDeployedContracts = testing.env.USE_DEPLOYED_CONTRACTS(false);
   const l1DevMultisig = hasDeployedContracts

--- a/test/optimism/bridging-non-rebasable.integration.test.ts
+++ b/test/optimism/bridging-non-rebasable.integration.test.ts
@@ -5,7 +5,7 @@ import { wei } from "../../utils/wei";
 import optimism from "../../utils/optimism";
 import testing, { scenario } from "../../utils/testing";
 import { ScenarioTest } from "../../utils/testing";
-import { tokenRateAndTimestampPacked, refSlotTimestamp } from "../../utils/testing/helpers";
+import { tokenRateAndTimestampPacked, refSlotTimestamp, getExchangeRate } from "../../utils/testing/helpers";
 
 type ContextType = Awaited<ReturnType<ReturnType<typeof ctxFactory>>>
 
@@ -580,7 +580,10 @@ function bridgingTestsSuit(scenarioInstance: ScenarioTest<ContextType>) {
 function ctxFactory(depositAmount: BigNumber, withdrawalAmount: BigNumber) {
   return async () => {
     const networkName = env.network("TESTING_OPT_NETWORK", "mainnet");
-    const tokenRate = BigNumber.from('1164454276599657236000000000');
+    const tokenRateDecimals = BigNumber.from(27);
+    const totalPooledEther = BigNumber.from('9309904612343950493629678');
+    const totalShares = BigNumber.from('7975822843597609202337218');
+    const tokenRate = getExchangeRate(tokenRateDecimals, totalPooledEther, totalShares);
 
     const {
       l1Provider,
@@ -588,7 +591,7 @@ function ctxFactory(depositAmount: BigNumber, withdrawalAmount: BigNumber) {
       l1ERC20ExtendedTokensBridgeAdmin,
       l2ERC20ExtendedTokensBridgeAdmin,
       ...contracts
-    } = await optimism.testing(networkName).getIntegrationTestSetup(tokenRate);
+    } = await optimism.testing(networkName).getIntegrationTestSetup(totalPooledEther, totalShares);
 
     const l1Snapshot = await l1Provider.send("evm_snapshot", []);
     const l2Snapshot = await l2Provider.send("evm_snapshot", []);

--- a/test/optimism/deposit-gas-estimation.test.ts
+++ b/test/optimism/deposit-gas-estimation.test.ts
@@ -80,7 +80,7 @@ scenario("Optimism :: Bridging integration test", ctxFactory)
     } = ctx;
 
     const { accountA: tokenHolderA } = ctx.accounts;
-    const stEthPerToken = await l1Token.stEthPerToken();
+    const stEthPerToken = await l1Token.getStETHByWstETH(BigNumber.from(10).pow(27));
 
     await l1TokenRebasable
       .connect(tokenHolderA.l1Signer)
@@ -136,7 +136,7 @@ scenario("Optimism :: Bridging integration test", ctxFactory)
 async function ctxFactory() {
   const networkName = env.network("TESTING_OPT_NETWORK", "mainnet");
   console.log("networkName=", networkName);
-  const exchangeRate = BigNumber.from('1164454276599657236');
+  const exchangeRate = BigNumber.from('1164454276599657236000000000');
 
   const {
     l1Provider,

--- a/test/optimism/pushingTokenRate.e2e.test.ts
+++ b/test/optimism/pushingTokenRate.e2e.test.ts
@@ -17,7 +17,7 @@ scenario("Optimism :: Push token rate to Oracle E2E test", ctxFactory)
   })
 
   .step("Receive token rate", async (ctx) => {
-    const tokenRate = await ctx.l1Token.stEthPerToken();
+    const tokenRate = await ctx.l1Token.getStETHByWstETH(BigNumber.from(10).pow(27));
 
     const answer = await ctx.tokenRateOracle.latestAnswer();
     assert.equalBN(answer, tokenRate);

--- a/test/optimism/pushingTokenRate.integration.test.ts
+++ b/test/optimism/pushingTokenRate.integration.test.ts
@@ -6,7 +6,7 @@ import network from "../../utils/network";
 import testing, { scenario } from "../../utils/testing";
 import deploymentOracle from "../../utils/optimism/deploymentOracle";
 import { getBridgeExecutorParams } from "../../utils/bridge-executor";
-import { tokenRateAndTimestampPacked } from "../../utils/testing/helpers";
+import { getExchangeRate } from "../../utils/testing/helpers";
 import { BigNumber } from "ethers";
 import { getBlockTimestamp } from "../../utils/testing/helpers";
 import {
@@ -110,7 +110,10 @@ async function ctxFactory() {
   const tokenRateOutdatedDelay = 86400;
   const maxAllowedL2ToL1ClockLag = BigNumber.from(86400);
   const maxAllowedTokenRateDeviationPerDay = BigNumber.from(500);
-  const tokenRate = BigNumber.from('1164454276599657236000000000');
+  const totalPooledEther = BigNumber.from('9309904612343950493629678');
+  const totalShares = BigNumber.from('7975822843597609202337218');
+  const tokenRateDecimals = BigNumber.from(27);
+  const tokenRate = getExchangeRate(tokenRateDecimals, totalPooledEther, totalShares);
 
   const networkName = env.network("TESTING_OPT_NETWORK", "mainnet");
   const [l1Provider, l2Provider] = network
@@ -151,7 +154,8 @@ async function ctxFactory() {
     l1TokenRebasable.address,
     "Test Token",
     "TT",
-    tokenRate
+    totalPooledEther,
+    totalShares
   );
 
   const accountingOracle = await new AccountingOracleStub__factory(l1Deployer).deploy(

--- a/test/token/ERC20BridgedPermit.unit.test.ts
+++ b/test/token/ERC20BridgedPermit.unit.test.ts
@@ -613,21 +613,21 @@ unit("ERC20BridgedPermit", ctxFactory)
   .run();
 
 async function ctxFactory() {
+  /// ---------------------------
+  /// constants
+  /// ---------------------------
   const name = "ERC20 Test Token";
   const symbol = "ERC20";
   const version = "1";
-  const decimals = BigNumber.from('18');
+  const decimals = BigNumber.from(18);
   const premint = wei`100 ether`;
 
   const [deployer, owner, recipient, spender, holder, stranger] = await hre.ethers.getSigners();
-
-  await hre.network.provider.request({
-    method: "hardhat_impersonateAccount",
-    params: [hre.ethers.constants.AddressZero],
-  });
-
   const zero = await hre.ethers.getSigner(hre.ethers.constants.AddressZero);
 
+  /// ---------------------------
+  /// contracts
+  /// ---------------------------
   const erc20BridgedProxied = await erc20BridgedPermitUnderProxy(
     deployer,
     holder,
@@ -638,7 +638,15 @@ async function ctxFactory() {
     owner.address
   )
 
+  /// ---------------------------
+  /// setup
+  /// ---------------------------
   await erc20BridgedProxied.connect(owner).bridgeMint(holder.address, premint);
+
+  await hre.network.provider.request({
+    method: "hardhat_impersonateAccount",
+    params: [hre.ethers.constants.AddressZero],
+  });
 
   return {
     accounts: { deployer, owner, recipient, spender, holder, zero, stranger },

--- a/test/token/ERC20Permit.unit.test.ts
+++ b/test/token/ERC20Permit.unit.test.ts
@@ -322,7 +322,7 @@ function ctxFactoryFactory(
   return async () => {
     const decimalsToSet = 18;
     const decimals = BigNumber.from(10).pow(decimalsToSet);
-    const tokenRate = BigNumber.from('1164454276599657236');
+    const tokenRate = BigNumber.from('1164454276599657236000000000');
     const premintShares = wei.toBigNumber(wei`100 ether`);
     const premintTokens = tokenRate.mul(premintShares).div(decimals);
 

--- a/test/token/ERC20RebasableBridgedPermit.unit.test.ts
+++ b/test/token/ERC20RebasableBridgedPermit.unit.test.ts
@@ -1248,9 +1248,9 @@ async function ctxFactory() {
   const name = "StETH Test Token";
   const symbol = "StETH";
   const version = "1";
-  const decimals = BigNumber.from('18');
+  const decimals = BigNumber.from('27');
   const tenPowDecimals = BigNumber.from('10').pow(decimals);
-  const tokenRate = BigNumber.from('1164454276599657236');         // value taken from real contact on 23.04.24
+  const tokenRate = BigNumber.from('1164454276599657236000000000');         // value taken from real contact on 23.04.24
   const tokenRateOutdatedDelay = BigNumber.from(86400);            // 1 day
   const maxAllowedL2ToL1ClockLag = BigNumber.from(86400);          // 1 day
   const maxAllowedTokenRateDeviationPerDay = BigNumber.from(500);  // 5%
@@ -1283,7 +1283,7 @@ async function ctxFactory() {
     owner.address
   );
 
-  const tokenRateOracle = await tokenRateOracleUnderProxy(
+  const { tokenRateOracle } = await tokenRateOracleUnderProxy(
     deployer,
     zero.address,
     owner.address,

--- a/utils/deployment.ts
+++ b/utils/deployment.ts
@@ -12,6 +12,7 @@ interface ChainDeploymentConfig extends BridgingManagerSetupConfig {
 interface MultiChainDeploymentConfig {
   l1Token: string;
   l1RebasableToken: string;
+  accountingOracle: string;
   l1OpStackTokenRatePusher: string;
   l2GasLimitForPushingTokenRate: number;
   tokenRateOutdatedDelay: number;
@@ -28,6 +29,7 @@ export function loadMultiChainDeploymentConfig(): MultiChainDeploymentConfig {
   return {
     l1Token: env.address("TOKEN"),
     l1RebasableToken: env.address("REBASABLE_TOKEN"),
+    accountingOracle: env.address("ACCOUNTING_ORACLE"),
     l1OpStackTokenRatePusher: env.address("L1_OP_STACK_TOKEN_RATE_PUSHER"),
     l2GasLimitForPushingTokenRate: Number(env.string("L2_GAS_LIMIT_FOR_PUSHING_TOKEN_RATE")),
     tokenRateOutdatedDelay: Number(env.string("TOKEN_RATE_OUTDATED_DELAY")),

--- a/utils/optimism/deploymentAllFromScratch.ts
+++ b/utils/optimism/deploymentAllFromScratch.ts
@@ -108,6 +108,7 @@ export default function deploymentAll(
     async deployAllScript(
       l1Token: string,
       l1TokenRebasable: string,
+      accountingOracle: string,
       l1Params: OptL1DeployScriptParams,
       l2Params: OptL2DeployScriptParams,
     ): Promise<[L1DeployAllScript, L2DeployAllScript]> {
@@ -147,6 +148,7 @@ export default function deploymentAll(
             l1TokenRebasable,
             expectedL2TokenProxyAddress,
             expectedL2TokenRebasableProxyAddress,
+            accountingOracle,
             options?.overrides,
           ],
           afterDeploy: (c) =>
@@ -180,6 +182,7 @@ export default function deploymentAll(
           args: [
             optAddresses.L1CrossDomainMessenger,
             l1Token,
+            accountingOracle,
             expectedL2TokenRateOracleProxyAddress,
             1000,
             options?.overrides,

--- a/utils/optimism/deploymentOracle.ts
+++ b/utils/optimism/deploymentOracle.ts
@@ -63,6 +63,7 @@ export default function deploymentOracle(
   return {
     async oracleDeployScript(
       l1Token: string,
+      accountingOracle: string,
       l2GasLimitForPushingTokenRate: number,
       tokenRateOutdatedDelay: number,
       l1Params: OptDeployScriptParams,
@@ -99,6 +100,7 @@ export default function deploymentOracle(
           args: [
             optAddresses.L1CrossDomainMessenger,
             l1Token,
+            accountingOracle,
             expectedL2TokenRateOracleProxyAddress,
             l2GasLimitForPushingTokenRate,
             options?.overrides,

--- a/utils/optimism/testing.ts
+++ b/utils/optimism/testing.ts
@@ -15,6 +15,7 @@ import {
   L2ERC20ExtendedTokensBridge__factory,
   CrossDomainMessengerStub__factory,
   ERC20RebasableBridgedPermit__factory,
+  AccountingOracleStub__factory
 } from "../../typechain";
 import addresses from "./addresses";
 import contracts from "./contracts";
@@ -163,6 +164,10 @@ async function loadDeployedBridges(
       testingUtils.env.OPT_L1_REBASABLE_TOKEN(),
       l1SignerOrProvider
     ),
+    accountingOracle: AccountingOracleStub__factory.connect(
+      testingUtils.env.OPT_L1_REBASABLE_TOKEN(),
+      l1SignerOrProvider
+    ),
 
     ...connectBridgeContracts(
       {
@@ -199,11 +204,18 @@ async function deployTestBridge(
     tokenRate
   );
 
+  const accountingOracle = await new AccountingOracleStub__factory(ethDeployer).deploy(
+    1,
+    2,
+    3
+  );
+
   const [ethDeployScript, optDeployScript] = await deploymentAll(
     networkName
   ).deployAllScript(
     l1Token.address,
     l1TokenRebasable.address,
+    accountingOracle.address,
     {
       deployer: ethDeployer,
       admins: { proxy: ethDeployer.address, bridge: ethDeployer.address },
@@ -248,6 +260,7 @@ async function deployTestBridge(
   return {
     l1Token: l1Token.connect(ethProvider),
     l1TokenRebasable: l1TokenRebasable.connect(ethProvider),
+    accountingOracle: accountingOracle.connect(ethProvider),
     ...connectBridgeContracts(
       {
         tokenRateOracle: optDeployScript.tokenRateOracleProxyAddress,

--- a/utils/testing/contractsFactory.ts
+++ b/utils/testing/contractsFactory.ts
@@ -1,117 +1,124 @@
+import hre from "hardhat";
 import { BigNumber } from "ethers";
 import { SignerWithAddress } from "@nomiclabs/hardhat-ethers/signers";
 import {
-    ERC20BridgedPermit__factory,
-    TokenRateOracle__factory,
-    ERC20RebasableBridgedPermit__factory,
-    OssifiableProxy__factory,
-    TokenRateOracle,
-    ERC20BridgedPermit
+  ERC20BridgedPermit__factory,
+  TokenRateOracle__factory,
+  ERC20RebasableBridgedPermit__factory,
+  OssifiableProxy__factory,
+  TokenRateOracle,
+  ERC20BridgedPermit
 } from "../../typechain";
 
 export async function erc20BridgedPermitUnderProxy(
-    deployer: SignerWithAddress,
-    holder: SignerWithAddress,
-    name: string,
-    symbol: string,
-    version: string,
-    decimals: BigNumber,
-    bridge: string
+  deployer: SignerWithAddress,
+  holder: SignerWithAddress,
+  name: string,
+  symbol: string,
+  version: string,
+  decimals: BigNumber,
+  bridge: string
 ) {
-    const erc20BridgedPermitImpl = await new ERC20BridgedPermit__factory(deployer).deploy(
-        name,
-        symbol,
-        version,
-        decimals,
-        bridge
-    );
+  const erc20BridgedPermitImpl = await new ERC20BridgedPermit__factory(deployer).deploy(
+    name,
+    symbol,
+    version,
+    decimals,
+    bridge
+  );
 
-    const erc20BridgedPermitProxy = await new OssifiableProxy__factory(deployer).deploy(
-        erc20BridgedPermitImpl.address,
-        deployer.address,
-        ERC20BridgedPermit__factory.createInterface().encodeFunctionData("initialize", [
-            name,
-            symbol,
-            version
-        ])
-    );
+  const erc20BridgedPermitProxy = await new OssifiableProxy__factory(deployer).deploy(
+    erc20BridgedPermitImpl.address,
+    deployer.address,
+    ERC20BridgedPermit__factory.createInterface().encodeFunctionData("initialize", [
+      name,
+      symbol,
+      version
+    ])
+  );
 
-    return ERC20BridgedPermit__factory.connect(
-        erc20BridgedPermitProxy.address,
-        holder
-    );
+  return ERC20BridgedPermit__factory.connect(
+    erc20BridgedPermitProxy.address,
+    holder
+  );
 }
 
 export async function tokenRateOracleUnderProxy(
-    deployer: SignerWithAddress,
-
-    messenger: string,
-    l2ERC20TokenBridge: string,
-    l1TokenRatePusher: string,
-    tokenRateOutdatedDelay: BigNumber,
-    maxAllowedL2ToL1ClockLag: BigNumber,
-    maxAllowedTokenRateDeviationPerDay: BigNumber,
-
-    tokenRate: BigNumber,
-    blockTimestamp: BigNumber
+  deployer: SignerWithAddress,
+  messenger: string,
+  l2ERC20TokenBridge: string,
+  l1TokenRatePusher: string,
+  tokenRateOutdatedDelay: BigNumber,
+  maxAllowedL2ToL1ClockLag: BigNumber,
+  maxAllowedTokenRateDeviationPerDay: BigNumber,
+  tokenRate: BigNumber,
+  rateL1Timestamp: BigNumber
 ) {
-    const tokenRateOracleImpl = await new TokenRateOracle__factory(deployer).deploy(
-        messenger,
-        l2ERC20TokenBridge,
-        l1TokenRatePusher,
-        tokenRateOutdatedDelay,
-        maxAllowedL2ToL1ClockLag,
-        maxAllowedTokenRateDeviationPerDay
-    );
-    const tokenRateOracleProxy = await new OssifiableProxy__factory(
-        deployer
-    ).deploy(
-        tokenRateOracleImpl.address,
-        deployer.address,
-        tokenRateOracleImpl.interface.encodeFunctionData("initialize", [
-            tokenRate,
-            blockTimestamp
-        ])
-    );
-    return TokenRateOracle__factory.connect(
-        tokenRateOracleProxy.address,
-        deployer
-    );
+  const tokenRateOracleImpl = await new TokenRateOracle__factory(deployer).deploy(
+    messenger,
+    l2ERC20TokenBridge,
+    l1TokenRatePusher,
+    tokenRateOutdatedDelay,
+    maxAllowedL2ToL1ClockLag,
+    maxAllowedTokenRateDeviationPerDay
+  );
+
+  const tokenRateOracleProxy = new OssifiableProxy__factory(deployer);
+
+  const unsignedTx = tokenRateOracleProxy.getDeployTransaction(tokenRateOracleImpl.address,
+    deployer.address,
+    tokenRateOracleImpl.interface.encodeFunctionData("initialize", [
+      tokenRate,
+      rateL1Timestamp
+    ]));
+
+  const response = await deployer.sendTransaction(unsignedTx);
+  const provider = await hre.ethers.provider;
+  const contractReceipt = await response.wait();
+  const blockTimestampOfDeployment = BigNumber.from((await provider.getBlock(contractReceipt.blockNumber)).timestamp);
+  const txResponse = await response.wait();
+
+  const tokenRateOracle = TokenRateOracle__factory.connect(
+    txResponse.contractAddress,
+    deployer
+  );
+
+  return { tokenRateOracle, blockTimestampOfDeployment };
 }
 
 export async function erc20RebasableBridgedPermitUnderProxy(
-    deployer: SignerWithAddress,
-    holder: SignerWithAddress,
-    name: string,
-    symbol: string,
-    version: string,
-    decimals: BigNumber,
-    tokenRateOracle: TokenRateOracle,
-    erc20BridgedPermit: ERC20BridgedPermit,
-    bridge: string
+  deployer: SignerWithAddress,
+  holder: SignerWithAddress,
+  name: string,
+  symbol: string,
+  version: string,
+  decimals: BigNumber,
+  tokenRateOracle: TokenRateOracle,
+  erc20BridgedPermit: ERC20BridgedPermit,
+  bridge: string
 ) {
-    const erc20RebasableBridgedPermitImpl = await new ERC20RebasableBridgedPermit__factory(deployer).deploy(
-        name,
-        symbol,
-        version,
-        decimals,
-        erc20BridgedPermit.address,
-        tokenRateOracle.address,
-        bridge
-    );
+  const erc20RebasableBridgedPermitImpl = await new ERC20RebasableBridgedPermit__factory(deployer).deploy(
+    name,
+    symbol,
+    version,
+    decimals,
+    erc20BridgedPermit.address,
+    tokenRateOracle.address,
+    bridge
+  );
 
-    const erc20RebasableBridgedPermitProxy = await new OssifiableProxy__factory(deployer).deploy(
-        erc20RebasableBridgedPermitImpl.address,
-        deployer.address,
-        ERC20RebasableBridgedPermit__factory.createInterface().encodeFunctionData("initialize", [
-            name,
-            symbol,
-            version,
-        ])
-    );
+  const erc20RebasableBridgedPermitProxy = await new OssifiableProxy__factory(deployer).deploy(
+    erc20RebasableBridgedPermitImpl.address,
+    deployer.address,
+    ERC20RebasableBridgedPermit__factory.createInterface().encodeFunctionData("initialize", [
+      name,
+      symbol,
+      version,
+    ])
+  );
 
-    return ERC20RebasableBridgedPermit__factory.connect(
-        erc20RebasableBridgedPermitProxy.address,
-        holder
-    );
+  return ERC20RebasableBridgedPermit__factory.connect(
+    erc20RebasableBridgedPermitProxy.address,
+    holder
+  );
 }

--- a/utils/testing/helpers.ts
+++ b/utils/testing/helpers.ts
@@ -1,0 +1,96 @@
+import { utils, BigNumber, ethers } from "ethers";
+import { ContractTransaction } from "@ethersproject/contracts";
+import { JsonRpcProvider } from "@ethersproject/providers";
+import { ERC20WrapperStub, AccountingOracleStub } from "../../typechain";
+import { SignerWithAddress } from "@nomiclabs/hardhat-ethers/signers";
+import { getContractAddress } from "ethers/lib/utils";
+
+export async function getContractTransactionTimestamp(provider: JsonRpcProvider, tx: ContractTransaction) {
+  const contractReceipt = await tx.wait();
+  return BigNumber.from((await provider.getBlock(contractReceipt.blockNumber)).timestamp);
+}
+
+export async function getBlockTimestamp(provider: JsonRpcProvider, secondsToShift: number) {
+  const blockNumber = await provider.getBlockNumber();
+  return BigNumber.from((await provider.getBlock(blockNumber)).timestamp + secondsToShift);
+}
+
+export function getInterfaceID(contractInterface: utils.Interface) {
+  let interfaceID = ethers.constants.Zero;
+  const functions: string[] = Object.keys(contractInterface.functions);
+  for (let i = 0; i < functions.length; i++) {
+    interfaceID = interfaceID.xor(contractInterface.getSighash(functions[i]));
+  }
+  return interfaceID;
+}
+
+export async function packedTokenRateAndTimestamp(provider: JsonRpcProvider, l1Token: ERC20WrapperStub) {
+  const stEthPerToken = await l1Token.getStETHByWstETH(BigNumber.from(10).pow(27));
+  const stEthPerTokenStr = ethers.utils.hexZeroPad(stEthPerToken.toHexString(), 16);
+
+  const blockNumber = await provider.getBlockNumber();
+  const blockTimestamp = (await provider.getBlock(blockNumber)).timestamp;
+  const blockTimestampStr = ethers.utils.hexZeroPad(ethers.utils.hexlify(blockTimestamp), 5);
+
+  return ethers.utils.hexConcat([stEthPerTokenStr, blockTimestampStr]);
+}
+
+async function packedTokenRateAndTimestamp2(provider: JsonRpcProvider, tokenRate: BigNumber) {
+  const stEthPerTokenStr = ethers.utils.hexZeroPad(tokenRate.toHexString(), 16);
+
+  const blockNumber = await provider.getBlockNumber();
+  const blockTimestamp = (await provider.getBlock(blockNumber)).timestamp;
+  const blockTimestampStr = ethers.utils.hexZeroPad(ethers.utils.hexlify(blockTimestamp), 5);
+
+  return ethers.utils.hexConcat([stEthPerTokenStr, blockTimestampStr]);
+}
+
+export async function packedTokenRateAndTimestampForL1Bridge(
+  l1Token: ERC20WrapperStub,
+  accountingOracle: AccountingOracleStub
+) {
+  const stEthPerToken = await l1Token.getStETHByWstETH(BigNumber.from(10).pow(27));
+  const stEthPerTokenStr = ethers.utils.hexZeroPad(stEthPerToken.toHexString(), 16);
+
+  const genesisTime = await accountingOracle.GENESIS_TIME();
+  const secondsPerSlot = await accountingOracle.SECONDS_PER_SLOT();
+  const lastProcessingRefSlot = await accountingOracle.lastProcessingRefSlot();
+  const refSlotTimestamp = genesisTime.add(secondsPerSlot.mul(lastProcessingRefSlot));
+  const blockTimestampStr = ethers.utils.hexZeroPad(ethers.utils.hexlify(refSlotTimestamp), 5);
+
+  return ethers.utils.hexConcat([stEthPerTokenStr, blockTimestampStr]);
+}
+
+export async function tokenRateAndTimestamp(tokenRate: BigNumber, blockTimestamp: BigNumber) {
+  const stEthPerTokenStr = ethers.utils.hexZeroPad(tokenRate.toHexString(), 16);
+  const blockTimestampStr = ethers.utils.hexZeroPad(ethers.utils.hexlify(blockTimestamp), 5);
+  return [stEthPerTokenStr, blockTimestampStr];
+}
+
+export async function tokenRateAndTimestampPacked(tokenRate: BigNumber, blockTimestamp: BigNumber, data: string) {
+  const stEthPerTokenStr = ethers.utils.hexZeroPad(tokenRate.toHexString(), 16);
+  const blockTimestampStr = ethers.utils.hexZeroPad(ethers.utils.hexlify(blockTimestamp), 5);
+  return ethers.utils.hexConcat([stEthPerTokenStr, blockTimestampStr, data]);
+}
+
+export async function refSlotTimestamp(accountingOracle: AccountingOracleStub) {
+  const genesisTime = await accountingOracle.GENESIS_TIME();
+  const secondsPerSlot = await accountingOracle.SECONDS_PER_SLOT();
+  const lastProcessingRefSlot = await accountingOracle.getLastProcessingRefSlot();
+  return genesisTime.add(secondsPerSlot.mul(lastProcessingRefSlot));
+}
+
+export async function predictAddresses(account: SignerWithAddress, txsCount: number) {
+  const currentNonce = await account.getTransactionCount();
+
+  const res: string[] = [];
+  for (let i = 0; i < txsCount; ++i) {
+    res.push(
+      getContractAddress({
+        from: account.address,
+        nonce: currentNonce + i,
+      })
+    );
+  }
+  return res;
+}

--- a/utils/testing/helpers.ts
+++ b/utils/testing/helpers.ts
@@ -55,3 +55,38 @@ export async function predictAddresses(account: SignerWithAddress, txsCount: num
   }
   return res;
 }
+
+export function getExchangeRate(decimals: BigNumber, totalPooledEther: BigNumber, totalShares: BigNumber) {
+  return (BigNumber.from(10).pow(decimals)).mul(totalPooledEther).div(totalShares);
+}
+
+/// token / rate
+export function nonRebasableFromRebasableL1(rebasable: BigNumber, totalPooledEther: BigNumber, totalShares: BigNumber) {
+  return rebasable
+    .mul(totalShares)
+    .div(totalPooledEther);
+}
+
+/// token * rate
+export function rebasableFromNonRebasableL1(rebasable: BigNumber, totalPooledEther: BigNumber, totalShares: BigNumber) {
+  return rebasable
+    .mul(totalPooledEther)
+    .div(totalShares);
+}
+
+export function nonRebasableFromRebasableL2(rebasable: BigNumber, decimals: BigNumber, exchangeRate: BigNumber) {
+  return rebasable
+    .mul(BigNumber.from(10).pow(decimals))
+    .div(exchangeRate);
+}
+
+export function rebasableFromNonRebasableL2(nonRebasable: BigNumber, decimals: BigNumber, exchangeRate: BigNumber) {
+  return nonRebasable
+    .mul(exchangeRate)
+    .div(BigNumber.from(10).pow(decimals));
+}
+
+export function almostEqual(num1: BigNumber, num2: BigNumber) {
+  const delta = (num1.sub(num2)).abs();
+  return delta.lte(BigNumber.from('2'));
+}

--- a/utils/testing/helpers.ts
+++ b/utils/testing/helpers.ts
@@ -1,7 +1,7 @@
 import { utils, BigNumber, ethers } from "ethers";
 import { ContractTransaction } from "@ethersproject/contracts";
 import { JsonRpcProvider } from "@ethersproject/providers";
-import { ERC20WrapperStub, AccountingOracleStub } from "../../typechain";
+import { AccountingOracleStub } from "../../typechain";
 import { SignerWithAddress } from "@nomiclabs/hardhat-ethers/signers";
 import { getContractAddress } from "ethers/lib/utils";
 
@@ -15,62 +15,14 @@ export async function getBlockTimestamp(provider: JsonRpcProvider, secondsToShif
   return BigNumber.from((await provider.getBlock(blockNumber)).timestamp + secondsToShift);
 }
 
-export function getInterfaceID(contractInterface: utils.Interface) {
-  let interfaceID = ethers.constants.Zero;
-  const functions: string[] = Object.keys(contractInterface.functions);
-  for (let i = 0; i < functions.length; i++) {
-    interfaceID = interfaceID.xor(contractInterface.getSighash(functions[i]));
-  }
-  return interfaceID;
-}
-
-export async function packedTokenRateAndTimestamp(provider: JsonRpcProvider, l1Token: ERC20WrapperStub) {
-  const stEthPerToken = await l1Token.getStETHByWstETH(BigNumber.from(10).pow(27));
-  const stEthPerTokenStr = ethers.utils.hexZeroPad(stEthPerToken.toHexString(), 16);
-
-  const blockNumber = await provider.getBlockNumber();
-  const blockTimestamp = (await provider.getBlock(blockNumber)).timestamp;
-  const blockTimestampStr = ethers.utils.hexZeroPad(ethers.utils.hexlify(blockTimestamp), 5);
-
-  return ethers.utils.hexConcat([stEthPerTokenStr, blockTimestampStr]);
-}
-
-async function packedTokenRateAndTimestamp2(provider: JsonRpcProvider, tokenRate: BigNumber) {
-  const stEthPerTokenStr = ethers.utils.hexZeroPad(tokenRate.toHexString(), 16);
-
-  const blockNumber = await provider.getBlockNumber();
-  const blockTimestamp = (await provider.getBlock(blockNumber)).timestamp;
-  const blockTimestampStr = ethers.utils.hexZeroPad(ethers.utils.hexlify(blockTimestamp), 5);
-
-  return ethers.utils.hexConcat([stEthPerTokenStr, blockTimestampStr]);
-}
-
-export async function packedTokenRateAndTimestampForL1Bridge(
-  l1Token: ERC20WrapperStub,
-  accountingOracle: AccountingOracleStub
-) {
-  const stEthPerToken = await l1Token.getStETHByWstETH(BigNumber.from(10).pow(27));
-  const stEthPerTokenStr = ethers.utils.hexZeroPad(stEthPerToken.toHexString(), 16);
-
-  const genesisTime = await accountingOracle.GENESIS_TIME();
-  const secondsPerSlot = await accountingOracle.SECONDS_PER_SLOT();
-  const lastProcessingRefSlot = await accountingOracle.lastProcessingRefSlot();
-  const refSlotTimestamp = genesisTime.add(secondsPerSlot.mul(lastProcessingRefSlot));
-  const blockTimestampStr = ethers.utils.hexZeroPad(ethers.utils.hexlify(refSlotTimestamp), 5);
-
-  return ethers.utils.hexConcat([stEthPerTokenStr, blockTimestampStr]);
-}
-
-export async function tokenRateAndTimestamp(tokenRate: BigNumber, blockTimestamp: BigNumber) {
-  const stEthPerTokenStr = ethers.utils.hexZeroPad(tokenRate.toHexString(), 16);
-  const blockTimestampStr = ethers.utils.hexZeroPad(ethers.utils.hexlify(blockTimestamp), 5);
-  return [stEthPerTokenStr, blockTimestampStr];
-}
-
 export async function tokenRateAndTimestampPacked(tokenRate: BigNumber, blockTimestamp: BigNumber, data: string) {
-  const stEthPerTokenStr = ethers.utils.hexZeroPad(tokenRate.toHexString(), 16);
-  const blockTimestampStr = ethers.utils.hexZeroPad(ethers.utils.hexlify(blockTimestamp), 5);
-  return ethers.utils.hexConcat([stEthPerTokenStr, blockTimestampStr, data]);
+  return ethers.utils.hexConcat(
+    [
+      ethers.utils.hexZeroPad(tokenRate.toHexString(), 16),
+      ethers.utils.hexZeroPad(blockTimestamp.toHexString(), 5),
+      data
+    ]
+  );
 }
 
 export async function refSlotTimestamp(accountingOracle: AccountingOracleStub) {
@@ -78,6 +30,15 @@ export async function refSlotTimestamp(accountingOracle: AccountingOracleStub) {
   const secondsPerSlot = await accountingOracle.SECONDS_PER_SLOT();
   const lastProcessingRefSlot = await accountingOracle.getLastProcessingRefSlot();
   return genesisTime.add(secondsPerSlot.mul(lastProcessingRefSlot));
+}
+
+export function getInterfaceID(contractInterface: utils.Interface) {
+  let interfaceID = ethers.constants.Zero;
+  const functions: string[] = Object.keys(contractInterface.functions);
+  for (let i = 0; i < functions.length; i++) {
+    interfaceID = interfaceID.xor(contractInterface.getSighash(functions[i]));
+  }
+  return interfaceID;
 }
 
 export async function predictAddresses(account: SignerWithAddress, txsCount: number) {


### PR DESCRIPTION
Here is the idea of the updated rate reporting approach

- [x] Addresses rounding issues (using 27 decimals for token rate)
- [x] Addresses the issue with the Oracle report frontrunning
- [x] Improve the semantics of `latestRoundData` and `isLikelyOutdated`

—

:warning: Hasn't been covered with tests, something might be broken