### PR TITLE
fix: bump optimism sdk version to fix error prove-message.ts script

### DIFF
--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
     "typescript": "^4.6.3"
   },
   "dependencies": {
-    "@eth-optimism/sdk": "3.2.3",
+    "@eth-optimism/sdk": "3.3.2",
     "@ethersproject/providers": "^5.6.8",
     "@lidofinance/evm-script-decoder": "^0.2.2",
     "@openzeppelin/contracts": "4.6.0",


### PR DESCRIPTION
On previous Optimism SDK version 3.2.3 ./scripts/optimism/prove-message.ts ceased to operate with an error like
```
Error: call revert exception [ See: https://links.ethers.org/v5-errors-CALL_EXCEPTION ] (method="gameCount()", data="0x", errorArgs=null, errorName=null, errorSignature=null, reason=null, code=CALL_EXCEPTION, version=abi/5.7.0)
    at Logger.makeError (/Users/arwer/projects/lido-l2-with-steth/node_modules/@ethersproject/logger/src.ts/index.ts:269:28)
    at Logger.throwError (/Users/arwer/projects/lido-l2-with-steth/node_modules/@ethersproject/logger/src.ts/index.ts:281:20)
    at Interface.decodeFunctionResult (/Users/arwer/projects/lido-l2-with-steth/node_modules/@ethersproject/abi/src.ts/interface.ts:427:23)
    at Contract.<anonymous> (/Users/arwer/projects/lido-l2-with-steth/node_modules/@ethersproject/contracts/src.ts/index.ts:400:44)
    at step (/Users/arwer/projects/lido-l2-with-steth/node_modules/@ethersproject/contracts/lib/index.js:48:23)
    at Object.next (/Users/arwer/projects/lido-l2-with-steth/node_modules/@ethersproject/contracts/lib/index.js:29:53)
    at fulfilled (/Users/arwer/projects/lido-l2-with-steth/node_modules/@ethersproject/contracts/lib/index.js:20:58)
    at processTicksAndRejections (node:internal/process/task_queues:95:5) {
  reason: null,
  code: 'CALL_EXCEPTION',
  method: 'gameCount()',
  data: '0x',
  errorArgs: null,
  errorName: null,
  errorSignature: null,
  address: '0x0000000000000000000000000000000000000000',
  args: [],
  transaction: {
    data: '0x4d1975b4',
    to: '0x0000000000000000000000000000000000000000',
    from: '<SENDER-ADDRESS-PLACEHOLDER>'
  }
}
```
